### PR TITLE
INTEGRA-516 need to keep docs in synch

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -8,11 +8,11 @@ Mule 3.5+ with Anypoint Studio 5 or later
 
 == Installation
 
-Read the "Installation" section in the PDF document at https://github.com/anaplaninc/anaplan-mulesoft/raw/develop/doc/AnaplanConnectorforMuleSoft-Guide.pdf 
+Read the "Installation" section in the PDF document at https://github.com/anaplaninc/anaplan-mulesoft/blob/master/doc/AnaplanConnectorforMuleSoft-Guide.pdf 
 
 == Usage
 
-Read about Setup, Usage, and Execution in the same PDF document at https://github.com/anaplaninc/anaplan-mulesoft/raw/develop/doc/AnaplanConnectorforMuleSoft-Guide.pdf 
+Read about Setup, Usage, and Execution in the same PDF document at https://github.com/anaplaninc/anaplan-mulesoft/blob/master/doc/AnaplanConnectorforMuleSoft-Guide.pdf 
 
 == Reporting Issues 
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ For building a flow that does an Export from Anaplan, Import to Anaplan, Delete 
 Mule 3.5+ with Anypoint Studio 5 or later
 
 # Installation 
-Read the "Installation" section in the PDF document at [doc/AnaplanConnectorforMuleSoft-Guide.pdf](https://github.com/anaplaninc/anaplan-mulesoft/raw/develop/doc/AnaplanConnectorforMuleSoft-Guide.pdf)
+Read the "Installation" section in the PDF document at [doc/AnaplanConnectorforMuleSoft-Guide.pdf](https://github.com/anaplaninc/anaplan-mulesoft/blob/master/doc/AnaplanConnectorforMuleSoft-Guide.pdf)
 
 #Usage
-Read about Setup, Usage, and Execution in the same PDF document at [doc/AnaplanConnectorforMuleSoft-Guide.pdf](https://github.com/anaplaninc/anaplan-mulesoft/raw/develop/doc/AnaplanConnectorforMuleSoft-Guide.pdf)
+Read about Setup, Usage, and Execution in the same PDF document at [doc/AnaplanConnectorforMuleSoft-Guide.pdf](https://github.com/anaplaninc/anaplan-mulesoft/blob/master/doc/AnaplanConnectorforMuleSoft-Guide.pdf)
 
 # Reporting Issues
 We use GitHub:Issues for tracking issues with this connector. You can report enhancement requests or bugs at https://github.com/anaplaninc/anaplan-mulesoft/issues.


### PR DESCRIPTION
need to keep docs in synch between Anapedia and GitHub so the ReadMe now points
to  blob/master/doc/AnaplanConnectorforMuleSoft-Guide.pdf  instead of to
raw/develop