### PR TITLE
bug/INTEGRA-723: Mulesoft Export Performance

### DIFF
--- a/demo/anaplan-import/src/main/app/mule-app.properties
+++ b/demo/anaplan-import/src/main/app/mule-app.properties
@@ -8,7 +8,7 @@ anaplan.modelId=
 anaplan.importId=
 
 anaplan.columnSeparator=,
-anaplan.delimiter=\\"
+anaplan.delimiter="
 
 file.readFromDir=
 file.moveToDir=

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
     <url>http://anaplaninc.github.io/mvn-repos</url>
 
     <properties>
+        <jdk.version>1.8</jdk.version>
         <mockito.version>1.8.2</mockito.version>
         <gson.version>2.2.2</gson.version>
         <jdk.version>1.8</jdk.version>
@@ -128,5 +129,18 @@
             <url>http://anaplaninc.github.io/mvn-repos/</url>
         </repository>
     </distributionManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>${jdk.version}</source>
+                    <target>${jdk.version}</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -14,74 +14,91 @@
         <version>3.6.1</version>
     </parent>
 
-   <url>http://anaplaninc.github.io/mvn-repos</url>
+    <url>http://anaplaninc.github.io/mvn-repos</url>
 
     <properties>
         <mockito.version>1.8.2</mockito.version>
         <gson.version>2.2.2</gson.version>
-        <jdk.version>1.6</jdk.version>
+        <jdk.version>1.8</jdk.version>
         <category>Community</category>
         <licensePath>LICENSE.md</licensePath>
         <devkit.studio.package.skip>false</devkit.studio.package.skip>
         <github.global.server>github</github.global.server>
+        <eclipse.runtime.version>2.1.0</eclipse.runtime.version>
+        <anaplan.connect.version>1.3.6</anaplan.connect.version>
+        <com.google.code.gson.version>2.2.2</com.google.code.gson.version>
+        <commons.codec.version>1.6</commons.codec.version>
+        <commons.logging.version>1.1.1</commons.logging.version>
+        <org.apache.httpcomponents.fluent-hc.version>4.2.5</org.apache.httpcomponents.fluent-hc.version>
+        <org.apache.httpcomponents.httpclient.version>4.2.5</org.apache.httpcomponents.httpclient.version>
+        <org.apache.httpcomponents.httpclient-cache.version>4.2.5</org.apache.httpcomponents.httpclient-cache.version>
+        <org.apache.httpcomponents.httpcore.version>4.2.4</org.apache.httpcomponents.httpcore.version>
+        <org.apache.httpcomponents.httpmime.version>4.2.5</org.apache.httpcomponents.httpmime.version>
+        <org.apache.commons.commons-lang3.version>3.4</org.apache.commons.commons-lang3.version>
+        <org.apache.commons.commons-csv.version>1.2</org.apache.commons.commons-csv.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>eclipse</groupId>
             <artifactId>eclipse-runtime</artifactId>
-            <version>2.1.0</version>
+            <version>${eclipse.runtime.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.anaplan.connect</groupId>
+            <groupId>com.anaplan.client</groupId>
             <artifactId>anaplan-connect</artifactId>
-            <version>1-3-4-prod</version>
-       </dependency>
-        <dependency>
-            <groupId>com.lmax</groupId>
-            <artifactId>disruptor</artifactId>
-            <version>3.0.1</version>
+            <version>${anaplan.connect.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.2.2</version>
+            <version>${com.google.code.gson.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.6</version>
+            <version>${commons.codec.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
-            <version>1.1.1</version>
+            <version>${commons.logging.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>fluent-hc</artifactId>
-            <version>4.2.5</version>
+            <version>${org.apache.httpcomponents.fluent-hc.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.2.5</version>
+            <version>${org.apache.httpcomponents.httpclient.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient-cache</artifactId>
-            <version>4.2.5</version>
+            <version>${org.apache.httpcomponents.httpclient-cache.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <version>4.2.4</version>
+            <version>${org.apache.httpcomponents.httpcore.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpmime</artifactId>
-            <version>4.2.5</version>
+            <version>${org.apache.httpcomponents.httpmime.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${org.apache.commons.commons-lang3.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+            <version>${org.apache.commons.commons-csv.version}</version>
         </dependency>
     </dependencies>
 
@@ -95,7 +112,7 @@
         <repository>
             <id>anaplan-github-mvn-repo</id>
             <name>Anaplan Github MVN Repository</name>
-            <url>https://raw.githubusercontent.com/anaplaninc/anaplaninc.github.io/master/mvn-repos/</url>
+            <url>https://raw.githubusercontent.com/anaplaninc/anaplaninc.github.io/mvn-repo-ac/</url>
             <layout>default</layout>
             <snapshots>
 	            <enabled>true</enabled>

--- a/src/main/java/com/anaplan/connector/MulesoftAnaplanResponse.java
+++ b/src/main/java/com/anaplan/connector/MulesoftAnaplanResponse.java
@@ -29,6 +29,8 @@ import com.anaplan.connector.utils.LogUtil;
 import com.anaplan.connector.utils.OperationStatus;
 import com.anaplan.connector.utils.UserMessages;
 
+import org.apache.commons.lang3.StringUtils;
+
 
 /**
  * Translates Anaplan task results into connector friendly responses. Provides
@@ -42,36 +44,36 @@ import com.anaplan.connector.utils.UserMessages;
  */
 public class MulesoftAnaplanResponse implements Serializable {
 
-	private static final long serialVersionUID = 1L;
-	private final String responseMessage;
-	private final ServerFile serverFile;
-	private final ExportMetadata exportMetadata;
-	private final OperationStatus status;
-	private final String logContext;
-	private final Throwable exception;
+    private static final long serialVersionUID = 1L;
+    private final String responseMessage;
+    private final ServerFile serverFile;
+    private final ExportMetadata exportMetadata;
+    private final OperationStatus status;
+    private final String logContext;
+    private final Throwable exception;
 
-	/**
-	 * Constructor.
+    /**
+     * Constructor.
      *
-	 * @param responseMessage Response message, usually export data.
-	 * @param status status object.
-	 * @param serverFile ServerFile object returned from API.
-	 * @param exportMetaData Meta data for Export data.
-	 * @param failureCause Any server error during exporting data.
-	 * @param logContext Log context when building responses.
-	 */
-	private MulesoftAnaplanResponse(String responseMessage, OperationStatus status,
-			ServerFile serverFile, ExportMetadata exportMetaData,
-			Throwable failureCause, String logContext) {
-		this.responseMessage = responseMessage;
-		this.status = status;
-		this.serverFile = serverFile;
-		this.exportMetadata = exportMetaData;
-		this.exception = failureCause;
-		this.logContext = logContext;
+     * @param responseMessage Response message, usually export data.
+     * @param status status object.
+     * @param serverFile ServerFile object returned from API.
+     * @param exportMetaData Meta data for Export data.
+     * @param failureCause Any server error during exporting data.
+     * @param logContext Log context when building responses.
+     */
+    private MulesoftAnaplanResponse(String responseMessage, OperationStatus status,
+            ServerFile serverFile, ExportMetadata exportMetaData,
+            Throwable failureCause, String logContext) {
+        this.responseMessage = responseMessage;
+        this.status = status;
+        this.serverFile = serverFile;
+        this.exportMetadata = exportMetaData;
+        this.exception = failureCause;
+        this.logContext = logContext;
 
-		LogUtil.status(logContext, "created " + this.toString());
-	}
+        LogUtil.status(logContext, "created " + this.toString());
+    }
 
     /** Getters */
     public OperationStatus getStatus() {
@@ -98,311 +100,308 @@ public class MulesoftAnaplanResponse implements Serializable {
         return exception;
     }
 
-	/**
-	 * Uses the server cell-reader handler to read the server response contents
-	 * and then write it to a string-buffer to be returned as a response.
+    /**
+     * Uses the server cell-reader handler to read the server response contents
+     * and then write it to a string-buffer to be returned as a response.
      *
-	 * @param cellReader CellReader object to write server response.
-	 * @param logContext Log context for write data to the provided cell-reader.
-	 * @return The string response.
-	 * @throws AnaplanAPIException Exception thrown when reading rows of data.
-	 * @throws IOException Exception thrown when reading rows of data.
-	 */
-	private String writeResponse(CellReader cellReader, String logContext)
+     * @param cellReader CellReader object to write server response.
+     * @param logContext Log context for write data to the provided cell-reader.
+     * @return The string response.
+     * @throws AnaplanAPIException Exception thrown when reading rows of data.
+     * @throws IOException Exception thrown when reading rows of data.
+     */
+    private String writeResponse(CellReader cellReader, String logContext)
             throws AnaplanAPIException, IOException {
 
-		String stringBuffer = "";
-		final String header = cellReader.getWholeHeaderRow() + "\n";
-		LogUtil.debug(logContext, header);
+        StringBuilder sb = new StringBuilder();
+        final String header = StringUtils.join(cellReader.getHeaderRow(), ',');
+        sb.append(header);
+        LogUtil.debug(logContext, header);
 
-		// write response to string-buffer
-		stringBuffer += header;
-		String dataLine = cellReader.readWholeDataRow();
-		while (dataLine != null) {
-			dataLine += "\n";
-			LogUtil.trace(logContext, dataLine);
-			stringBuffer += dataLine;
-			dataLine = cellReader.readWholeDataRow();
-		}
-		LogUtil.debug(logContext, "finished writing file");
-		return stringBuffer;
-	}
+        String dataLine = StringUtils.join(cellReader.readDataRow(), ',');
 
-	/**
-	 * Finalizes the result sent back from the server and returns it as a
-	 * string.
+        String[] dataLineArr;
+        while (dataLine != null) {
+            sb.append("\n").append(dataLine);
+            dataLineArr = cellReader.readDataRow();
+            dataLine = (dataLineArr == null) ? null
+                    : StringUtils.join(dataLineArr, ',');
+        }
+        LogUtil.debug(logContext, "finished writing file");
+        return sb.toString();
+    }
+
+    /**
+     * Finalizes the result sent back from the server and returns it as a
+     * string.
      *
-	 * @param serverFile ServerFile object.
-	 * @param logContext Log context for creating response operation.
-	 * @throws IOException Exception thrown when reading rows of data.
-	 * @throws AnaplanAPIException Exception thrown when reading rows of data.
-	 */
-	private String responseServerFile(ServerFile serverFile, String logContext)
-			throws IOException, AnaplanAPIException {
-		if (serverFile == null) {
-			throw new AnaplanAPIException("Response is empty: " + getStatus());
-		}
-		final CellReader cellReader = serverFile.getDownloadCellReader();
-		if (getExportMetadata() != null) {
-			LogUtil.debug(logContext,
-					getExportMetadata().collectExportFileInfo());
-		}
-		return writeResponse(cellReader, logContext);
-	}
+     * @param serverFile ServerFile object.
+     * @param logContext Log context for creating response operation.
+     * @throws IOException Exception thrown when reading rows of data.
+     * @throws AnaplanAPIException Exception thrown when reading rows of data.
+     */
+    private String responseServerFile(ServerFile serverFile, String logContext)
+            throws IOException, AnaplanAPIException {
+        if (serverFile == null) {
+            throw new AnaplanAPIException("Response is empty: " + getStatus());
+        }
+        final CellReader cellReader = serverFile.getDownloadCellReader();
+//		if (getExportMetadata() != null) {
+//			LogUtil.debug(logContext,
+//					getExportMetadata().collectExportFileInfo());
+//		}
+        return writeResponse(cellReader, logContext);
+    }
 
-	/**
-	 * Writes the import data to Anaplan using the provided Import-ID and
-	 * connStrategy.
+    /**
+     * Writes the import data to Anaplan using the provided Import-ID and
+     * connStrategy.
      *
-	 * @param connection Anaplan API connection object.
-	 * @param importId Import action ID.
+     * @param connection Anaplan API connection object.
+     * @param importId Import action ID.
      * @throws AnaplanOperationException When server-file API object fails to import.
-	 * @throws IOException When server-file API object fails to import.
-	 * @throws AnaplanAPIException When server-file API object fails to import.
-	 */
-	public void writeImportData(AnaplanConnection connection, String importId)
-										throws AnaplanOperationException,
-											   IOException,
-											   AnaplanAPIException {
-		if (getServerFile() != null) {
-			responseServerFile(getServerFile(), getLogContext());
-		} else if (getStatus() == OperationStatus.SUCCESS) {
-			LogUtil.status(UserMessages.getMessage("importSuccess", importId),
-					getResponseMessage());
-		} else {
-			if (getException() == null) {
-				responseFail(connection, getResponseMessage());
-			} else {
-				responseEpicFail(connection, getException(),
-						getResponseMessage());
-			}
-		}
-	}
+     * @throws IOException When server-file API object fails to import.
+     * @throws AnaplanAPIException When server-file API object fails to import.
+     */
+    public void writeImportData(AnaplanConnection connection, String importId)
+            throws AnaplanOperationException,
+            IOException,
+            AnaplanAPIException {
+        if (getServerFile() != null) {
+            responseServerFile(getServerFile(), getLogContext());
+        } else if (getStatus() == OperationStatus.SUCCESS) {
+            LogUtil.status(UserMessages.getMessage("importSuccess", importId),
+                    getResponseMessage());
+        } else {
+            if (getException() == null) {
+                responseFail(connection, getResponseMessage());
+            } else {
+                responseEpicFail(connection, getException(),
+                        getResponseMessage());
+            }
+        }
+    }
 
-	/**
-	 * Reads the export-data from the registered Serverfile object and emits
-	 * the data as a string into the Mulesoft platform for the next
-	 * connector down the data-flow pipeline.
+    /**
+     * Reads the export-data from the registered Serverfile object and emits
+     * the data as a string into the Mulesoft platform for the next
+     * connector down the data-flow pipeline.
      *
-	 * @param connection Anaplan API connection object.
-	 * @throws IOException IO exception
+     * @param connection Anaplan API connection object.
+     * @throws IOException IO exception
      * @throws AnaplanAPIException
-	 * @throws AnaplanOperationException
-	 */
-	public String writeExportData(AnaplanConnection connection)
-										  throws IOException,
-										  		 AnaplanAPIException,
-										  		 AnaplanOperationException {
-		if (getStatus() != OperationStatus.SUCCESS) {
-			if (getException() == null) {
-				responseFail(connection, getResponseMessage());
-			} else {
-				responseEpicFail(connection, getException(),
-						getResponseMessage());
-			}
-		}
-		return responseServerFile(getServerFile(), getLogContext());
-	}
+     * @throws AnaplanOperationException
+     */
+    public String writeExportData(AnaplanConnection connection)
+            throws IOException,
+            AnaplanAPIException,
+            AnaplanOperationException {
+        if (getStatus() != OperationStatus.SUCCESS) {
+            if (getException() == null) {
+                responseFail(connection, getResponseMessage());
+            } else {
+                responseEpicFail(connection, getException(),
+                        getResponseMessage());
+            }
+        }
+        return responseServerFile(getServerFile(), getLogContext());
+    }
 
-	@Override
-	public String toString() {
-		String strBuffer = "";
-		strBuffer += "AnaplanResponse with status ";
-		strBuffer += this.status == null ? "null" : this.status.toString();
+    @Override
+    public String toString() {
+        StringBuilder strBuffer = new StringBuilder();
+        strBuffer.append("AnaplanResponse with status ");
+        strBuffer.append(this.status == null ? "null" : this.status.toString());
 
-		strBuffer += "; message: ";
-		strBuffer += this.responseMessage == null ? "null" : this.responseMessage;
+        strBuffer.append("; message: ");
+        strBuffer.append(this.responseMessage == null ? "null" : this.responseMessage);
 
-		strBuffer += "; serverfile ";
-		strBuffer += this.serverFile == null ? "null" : this.serverFile.getName();
+        strBuffer.append("; serverfile ");
+        strBuffer.append(this.serverFile == null ? "null" : this.serverFile.getName());
 
-		strBuffer += "; exportmetadata: ";
-		strBuffer += this.exportMetadata == null ? "null" : this.exportMetadata
-				.collectExportFileInfo();
+        return strBuffer.toString();
+    }
 
-		return strBuffer;
-	}
-
-	/**
-	 * Currently logs the error provided in 'reason' and creates a general
+    /**
+     * Currently logs the error provided in 'reason' and creates a general
      * Log4j.error() message.
      *
-	 * @param connection Anaplan API connection
-	 * @param reason Reason description for failed response.
-	 */
-	public static void responseFail(AnaplanConnection connection, String reason) {
-		LogUtil.error(connection.getLogContext(), "Aborting operation for all "
-				+ "documents in request: " + reason);
-	}
+     * @param connection Anaplan API connection
+     * @param reason Reason description for failed response.
+     */
+    public static void responseFail(AnaplanConnection connection, String reason) {
+        LogUtil.error(connection.getLogContext(), "Aborting operation for all "
+                + "documents in request: " + reason);
+    }
 
-	/**
-	 * Usually as a last resort to error-logging, whenever the cause of the
-	 * error is unknown and everything needs to be brought to a grinding halt.
-	 * In order to stop the flow, the Throwable is wrapped into a
-	 * AnaplanOperationException.
+    /**
+     * Usually as a last resort to error-logging, whenever the cause of the
+     * error is unknown and everything needs to be brought to a grinding halt.
+     * In order to stop the flow, the Throwable is wrapped into a
+     * AnaplanOperationException.
      *
-	 * @param connection Anaplan API connection.
-	 * @param e Throwable object containing Failure info
-	 * @param reason Reason for Epic Fail
-	 * @throws AnaplanOperationException Internal operation exception for
+     * @param connection Anaplan API connection.
+     * @param e Throwable object containing Failure info
+     * @param reason Reason for Epic Fail
+     * @throws AnaplanOperationException Internal operation exception for
      *      signalling epic fail.
-	 */
-	public static void responseEpicFail(AnaplanConnection connection,
-			Throwable e, String reason) throws AnaplanOperationException {
-		final String msg;
-		if (reason == null) {
-			msg = "Unexpected operation error: Generating OperationResponse "
-					+ "error for " + e.getMessage();
-		} else {
-			msg = reason + ": " + e.getMessage();
-		}
+     */
+    public static void responseEpicFail(AnaplanConnection connection,
+            Throwable e, String reason) throws AnaplanOperationException {
+        final String msg;
+        if (reason == null) {
+            msg = "Unexpected operation error: Generating OperationResponse "
+                    + "error for " + e.getMessage();
+        } else {
+            msg = reason + ": " + e.getMessage();
+        }
 
-		LogUtil.error(connection.getLogContext(), msg, e); // for stack trace
-		throw new AnaplanOperationException(e.getMessage());
-	}
+        LogUtil.error(connection.getLogContext(), msg, e); // for stack trace
+        throw new AnaplanOperationException(e.getMessage());
+    }
 
-	/**
-	 * Success response constructor whenever an export operation succeeds.
-	 *
-	 * @param responseMessage Response message from server for succesful export.
-	 * @param exportOutput Export output ServerFile object.
-	 * @param exportMetadata Export metadata.
-	 * @param logContext Log context for successful export.
-	 * @return Response object containing export data and details.
-	 * @throws IllegalArgumentException Thrown if null export output exists.
-	 */
-	public static MulesoftAnaplanResponse exportSuccess(String responseMessage,
-			ServerFile exportOutput, ExportMetadata exportMetadata,
-			String logContext) throws IllegalArgumentException {
-		if (exportOutput == null) {
-			LogUtil.error(logContext, "discarding response for task"
-					+ responseMessage);
-			throw new IllegalArgumentException(
-					"Output cannot be null for a successful export");
-		} else {
-			return new MulesoftAnaplanResponse(responseMessage,
-					OperationStatus.SUCCESS, exportOutput, exportMetadata,
-					null, logContext);
-		}
-	}
-
-	/**
-	 * Failure response constructor for data exports from Anaplan, whenever a
-	 * failure is encountered during a data-export. Most likely thrown due to
-	 * invalid Workspace-ID, Model-ID or Export-action-ID.
+    /**
+     * Success response constructor whenever an export operation succeeds.
      *
-	 * @param responseMessage Response message for export failure.
-	 * @param exportMetadata Metadata for export/
-	 * @param cause Throwable with info regarding export failure.
-	 * @param logContext Log context for this export failures.
-	 * @return Response object containing server details of Export failure.
-	 */
-	public static MulesoftAnaplanResponse exportFailure(String responseMessage,
-			ExportMetadata exportMetadata, Throwable cause, String logContext) {
-		return new MulesoftAnaplanResponse(responseMessage, OperationStatus.FAILURE,
-				null, exportMetadata, cause, logContext);
-	}
+     * @param responseMessage Response message from server for succesful export.
+     * @param exportOutput Export output ServerFile object.
+     * @param exportMetadata Export metadata.
+     * @param logContext Log context for successful export.
+     * @return Response object containing export data and details.
+     * @throws IllegalArgumentException Thrown if null export output exists.
+     */
+    public static MulesoftAnaplanResponse exportSuccess(String responseMessage,
+            ServerFile exportOutput, ExportMetadata exportMetadata,
+            String logContext) throws IllegalArgumentException {
+        if (exportOutput == null) {
+            LogUtil.error(logContext, "discarding response for task"
+                    + responseMessage);
+            throw new IllegalArgumentException(
+                    "Output cannot be null for a successful export");
+        } else {
+            return new MulesoftAnaplanResponse(responseMessage,
+                    OperationStatus.SUCCESS, exportOutput, exportMetadata,
+                    null, logContext);
+        }
+    }
 
-	/**
-	 * Success response constructor to signal a successful Import operation.
+    /**
+     * Failure response constructor for data exports from Anaplan, whenever a
+     * failure is encountered during a data-export. Most likely thrown due to
+     * invalid Workspace-ID, Model-ID or Export-action-ID.
      *
-	 * @param responseMessage Response message from import success.
-	 * @param logContext Log context for this successful import.
-	 * @param serverFile Object containing details of import.
-	 * @return Response object containing all response details regarding import.
-	 */
-	public static MulesoftAnaplanResponse importSuccess(String responseMessage,
-			String logContext, ServerFile serverFile) {
-		return new MulesoftAnaplanResponse(responseMessage, OperationStatus.SUCCESS,
-				serverFile, null, null, logContext);
-	}
+     * @param responseMessage Response message for export failure.
+     * @param exportMetadata Metadata for export/
+     * @param cause Throwable with info regarding export failure.
+     * @param logContext Log context for this export failures.
+     * @return Response object containing server details of Export failure.
+     */
+    public static MulesoftAnaplanResponse exportFailure(String responseMessage,
+            ExportMetadata exportMetadata, Throwable cause, String logContext) {
+        return new MulesoftAnaplanResponse(responseMessage, OperationStatus.FAILURE,
+                null, exportMetadata, cause, logContext);
+    }
 
-	/**
-	 * Failure response constructor used to signal a failure during an import
-	 * operation into Anaplan, which usually is because of malformed input data.
-	 *
-	 * @param responseMessage Response message from Import failure.
-	 * @param cause Throwable with info regarding import failure.
-	 * @param logContext Log context for this import failure.
-	 * @return Response object containing server details of Import failure.
-	 */
-	public static MulesoftAnaplanResponse importFailure(String responseMessage,
-			Throwable cause, String logContext) {
-		return new MulesoftAnaplanResponse(responseMessage, OperationStatus.FAILURE,
-				null, null, cause, logContext);
-	}
+    /**
+     * Success response constructor to signal a successful Import operation.
+     *
+     * @param responseMessage Response message from import success.
+     * @param logContext Log context for this successful import.
+     * @param serverFile Object containing details of import.
+     * @return Response object containing all response details regarding import.
+     */
+    public static MulesoftAnaplanResponse importSuccess(String responseMessage,
+            String logContext, ServerFile serverFile) {
+        return new MulesoftAnaplanResponse(responseMessage, OperationStatus.SUCCESS,
+                serverFile, null, null, logContext);
+    }
 
-	/**
-	 * Response constructor used when an Import operation fails and the server
-	 * provides a failure-dump to help debug.
-	 *
-	 * @param responseMessage Response message from Import failure.
-	 * @param failDump Failure dump log from server for debugging purposes.
-	 * @param logContext Log context for this import failure.
-	 * @return Response object containing server details of import failure.
-	 */
-	public static MulesoftAnaplanResponse importWithFailureDump(String responseMessage,
-			ServerFile failDump, String logContext) {
-		return new MulesoftAnaplanResponse(responseMessage,
-				OperationStatus.APPLICATION_ERROR, failDump, null, null,
-				logContext);
-	}
+    /**
+     * Failure response constructor used to signal a failure during an import
+     * operation into Anaplan, which usually is because of malformed input data.
+     *
+     * @param responseMessage Response message from Import failure.
+     * @param cause Throwable with info regarding import failure.
+     * @param logContext Log context for this import failure.
+     * @return Response object containing server details of Import failure.
+     */
+    public static MulesoftAnaplanResponse importFailure(String responseMessage,
+            Throwable cause, String logContext) {
+        return new MulesoftAnaplanResponse(responseMessage, OperationStatus.FAILURE,
+                null, null, cause, logContext);
+    }
 
-	/**
-	 * Success response constructor to signal a successful generic action
-	 * operation, such as a successful Delete operation or an M2M operation.
-	 *
-	 * @param responseMessage Success response message from Execute-Action.
-	 * @param logContext Log context for this execute-action behavior.
-	 * @return Response object containing execute-action success details.
-	 */
-	public static MulesoftAnaplanResponse executeActionSuccess(String responseMessage,
-			String logContext) {
-		return new MulesoftAnaplanResponse(responseMessage, OperationStatus.SUCCESS,
-				null, null, null, logContext);
-	}
+    /**
+     * Response constructor used when an Import operation fails and the server
+     * provides a failure-dump to help debug.
+     *
+     * @param responseMessage Response message from Import failure.
+     * @param failDump Failure dump log from server for debugging purposes.
+     * @param logContext Log context for this import failure.
+     * @return Response object containing server details of import failure.
+     */
+    public static MulesoftAnaplanResponse importWithFailureDump(String responseMessage,
+            ServerFile failDump, String logContext) {
+        return new MulesoftAnaplanResponse(responseMessage,
+                OperationStatus.APPLICATION_ERROR, failDump, null, null,
+                logContext);
+    }
 
-	/**
-	 * Failure response constructor from the connector whenever a generic
-	 * execute operation fails.
-	 *
-	 * @param responseMessage Failure response message from Execute-Action.
-	 * @param cause Throwable with failed execute action details.
-	 * @param logContext Log context for this execute-action failure.
-	 * @return Response object containing failed execute-action details.
-	 */
-	public static MulesoftAnaplanResponse executeActionFailure(String responseMessage,
-			Throwable cause, String logContext) {
-		return new MulesoftAnaplanResponse(responseMessage, OperationStatus.FAILURE,
-				null, null, cause, logContext);
-	}
+    /**
+     * Success response constructor to signal a successful generic action
+     * operation, such as a successful Delete operation or an M2M operation.
+     *
+     * @param responseMessage Success response message from Execute-Action.
+     * @param logContext Log context for this execute-action behavior.
+     * @return Response object containing execute-action success details.
+     */
+    public static MulesoftAnaplanResponse executeActionSuccess(String responseMessage,
+            String logContext) {
+        return new MulesoftAnaplanResponse(responseMessage, OperationStatus.SUCCESS,
+                null, null, null, logContext);
+    }
 
-	/**
-	 * Success response constructor from the connector whenever a Process operation
+    /**
+     * Failure response constructor from the connector whenever a generic
+     * execute operation fails.
+     *
+     * @param responseMessage Failure response message from Execute-Action.
+     * @param cause Throwable with failed execute action details.
+     * @param logContext Log context for this execute-action failure.
+     * @return Response object containing failed execute-action details.
+     */
+    public static MulesoftAnaplanResponse executeActionFailure(String responseMessage,
+            Throwable cause, String logContext) {
+        return new MulesoftAnaplanResponse(responseMessage, OperationStatus.FAILURE,
+                null, null, cause, logContext);
+    }
+
+    /**
+     * Success response constructor from the connector whenever a Process operation
      * succeeds on the server.
      *
-	 * @param responseMessage Success response message from running Process.
-	 * @param logContext Log context used when creating this response.
-	 * @return Response object containing Process success response details.
-	 */
-	public static MulesoftAnaplanResponse runProcessSuccess(String responseMessage,
-			String logContext) {
-		return new MulesoftAnaplanResponse(responseMessage, OperationStatus.SUCCESS,
-				null, null, null, logContext);
-	}
+     * @param responseMessage Success response message from running Process.
+     * @param logContext Log context used when creating this response.
+     * @return Response object containing Process success response details.
+     */
+    public static MulesoftAnaplanResponse runProcessSuccess(String responseMessage,
+            String logContext) {
+        return new MulesoftAnaplanResponse(responseMessage, OperationStatus.SUCCESS,
+                null, null, null, logContext);
+    }
 
-	/**
-	 * Failure response constructor from the connector whenever a Process
+    /**
+     * Failure response constructor from the connector whenever a Process
      * operation fails on the server.
      *
-	 * @param responseMessage Failure response message from server.
-	 * @param cause Throwable containing failure details.
-	 * @param logContext Log context used when creating this response.
-	 * @return Response object containing Process failure response details.
-	 */
-	public static MulesoftAnaplanResponse runProcessFailure(String responseMessage,
-			Throwable cause, String logContext) {
-		return new MulesoftAnaplanResponse(responseMessage, OperationStatus.FAILURE,
-				null, null, cause, logContext);
-	}
+     * @param responseMessage Failure response message from server.
+     * @param cause Throwable containing failure details.
+     * @param logContext Log context used when creating this response.
+     * @return Response object containing Process failure response details.
+     */
+    public static MulesoftAnaplanResponse runProcessFailure(String responseMessage,
+            Throwable cause, String logContext) {
+        return new MulesoftAnaplanResponse(responseMessage, OperationStatus.FAILURE,
+                null, null, cause, logContext);
+    }
 }

--- a/src/main/java/com/anaplan/connector/utils/AnaplanImportOperation.java
+++ b/src/main/java/com/anaplan/connector/utils/AnaplanImportOperation.java
@@ -74,7 +74,7 @@ public class AnaplanImportOperation extends BaseAnaplanOperation{
 	        String delimiter) throws IOException {
 
 		List<String> cellTokens;
-		List<String[]> rows = new ArrayList<String[]>();
+		List<String[]> rows = new ArrayList<>();
 
 		if (columnSeparator.length() > 1) {
             throw new IllegalArgumentException(

--- a/src/main/java/com/anaplan/connector/utils/AnaplanUtil.java
+++ b/src/main/java/com/anaplan/connector/utils/AnaplanUtil.java
@@ -28,57 +28,57 @@ import com.anaplan.client.TaskStatus;
  */
 public class AnaplanUtil {
 
-	private AnaplanUtil() {
-		// static-only
-	}
+    private AnaplanUtil() {
+        // static-only
+    }
 
-	/**
-	 * Prints an array of strings as a string, delimited by "||". This is for
-	 * debug logs only.
-	 *
-	 * @param toprint Data array to create debug string with.
-	 * @return Debug output for provided string array.
-	 */
-	public static String debug_output(String[] toprint) {
-		String sb = "";
-		for (String s : toprint) {
-			sb += s + "||";
-		}
-		if (sb.length() > 1) {
-			return sb.substring(0, sb.length() - 1);
-		} else {
-			return "*";
-		}
-	}
+    /**
+     * Prints an array of strings as a string, delimited by "||". This is for
+     * debug logs only.
+     *
+     * @param toprint Data array to create debug string with.
+     * @return Debug output for provided string array.
+     */
+    public static String debug_output(String[] toprint) {
+        StringBuilder sb = new StringBuilder();
+        for (String s : toprint) {
+            sb.append(s + "||");
+        }
+        if (sb.length() > 1) {
+            return sb.toString().substring(0, sb.length() - 1);
+        } else {
+            return "*";
+        }
+    }
 
-	/**
-	 * Executes an Anaplan task and polls the status until its complete.
-	 *
-	 * @param task Server task object to run.
-	 * @param logContext Log context to be used while running server task.
-	 * @return The status message from the running the task.
-	 * @throws AnaplanAPIException API exception thrown whenever server task
+    /**
+     * Executes an Anaplan task and polls the status until its complete.
+     *
+     * @param task Server task object to run.
+     * @param logContext Log context to be used while running server task.
+     * @return The status message from the running the task.
+     * @throws AnaplanAPIException API exception thrown whenever server task
      *      fails.
-	 */
-	public static TaskStatus runServerTask(Task task, String logContext)
-			throws AnaplanAPIException {
-		TaskStatus status = task.getStatus();
-		LogUtil.error(logContext, "TASK STATUS: " + status.getTaskState().toString());
-		while (status.getTaskState() != TaskStatus.State.COMPLETE
-				&& status.getTaskState() != TaskStatus.State.CANCELLED) {
+     */
+    public static TaskStatus runServerTask(Task task, String logContext)
+            throws AnaplanAPIException {
+        TaskStatus status = task.getStatus();
+        LogUtil.error(logContext, "TASK STATUS: " + status.getTaskState().toString());
+        while (status.getTaskState() != TaskStatus.State.COMPLETE
+                && status.getTaskState() != TaskStatus.State.CANCELLED) {
 
-			// if busy, nap and check again after 1 second
-			try {
-				Thread.sleep(1000);
-				LogUtil.debug(logContext, "Running Task = "
-						+ task.getStatus().getProgress());
-			} catch (InterruptedException e) {
-				LogUtil.error(logContext,
-						"Task interrupted!\n" + e.getMessage());
-			}
-			status = task.getStatus();
-		}
+            // if busy, nap and check again after 1 second
+            try {
+                Thread.sleep(1000);
+                LogUtil.debug(logContext, "Running Task = "
+                        + task.getStatus().getProgress());
+            } catch (InterruptedException e) {
+                LogUtil.error(logContext,
+                        "Task interrupted!\n" + e.getMessage());
+            }
+            status = task.getStatus();
+        }
 
-		return status;
-	}
+        return status;
+    }
 }


### PR DESCRIPTION
- Fixed Import and Export performance to use StringBuilder for MulesofAnaplanResponse.writeResponse(). Also fixed MulesoftAnaplanResponse.toString() to use StringBuilder as well.
- Using new Anaplan Connect Repo, the end-result of the mavenized Anaplan-Connect.
- Updated the Mule-App properties for the Import demo to use the proper delimiter with updated AC.
- Updated AnaplanImportOperation.parseImportData() changed to use the CSVParser.
- Fixed AnaplanUtil.debugOutput() to use StringBuilder.
- Fixed formatting for MulesoftAnaplanResponse.java from tabs to 4-spaces.