### PR TITLE
bug/INTEGRA-718: Mulesoft uses \t as text delimiter instead of comma for CSV file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
         <repository>
             <id>anaplan.mvn.repo</id>
             <name>Anaplan Github Maven Repo</name>
-            <url>http://anaplaninc.github.io/mvn-repos/</url>
+            <url>http://anaplaninc.github.io/mvn-repo-ac/</url>
         </repository>
     </distributionManagement>
 

--- a/src/main/java/com/anaplan/connector/AnaplanConnector.java
+++ b/src/main/java/com/anaplan/connector/AnaplanConnector.java
@@ -16,6 +16,7 @@
 
 package com.anaplan.connector;
 
+import com.anaplan.connector.utils.*;
 import org.mule.api.annotations.ConnectionStrategy;
 import org.mule.api.annotations.Connector;
 import org.mule.api.annotations.Processor;
@@ -27,10 +28,6 @@ import org.mule.api.annotations.param.Payload;
 import com.anaplan.connector.connection.BaseConnectionStrategy;
 import com.anaplan.connector.exceptions.AnaplanConnectionException;
 import com.anaplan.connector.exceptions.AnaplanOperationException;
-import com.anaplan.connector.utils.AnaplanDeleteOperation;
-import com.anaplan.connector.utils.AnaplanExportOperation;
-import com.anaplan.connector.utils.AnaplanImportOperation;
-import com.anaplan.connector.utils.AnaplanProcessOperation;
 
 
 /**
@@ -93,8 +90,10 @@ public class AnaplanConnector {
 			@FriendlyName("Workspace name or ID") String workspaceId,
 		    @FriendlyName("Model name or ID") String modelId,
 		    @FriendlyName("Import name or ID") String importId,
-			@FriendlyName("Column separator") @Default(",") String columnSeparator,
-			@FriendlyName("Delimiter") @Default("\"") String delimiter)
+			@FriendlyName("Column separator")
+			@Default(Delimiters.COMMA) String columnSeparator,
+			@FriendlyName("Delimiter")
+			@Default(Delimiters.ESCAPE_CHARACTER) String delimiter)
 		    		throws AnaplanConnectionException,
 		    			   AnaplanOperationException {
 		// validate API connectionStrategy

--- a/src/main/java/com/anaplan/connector/utils/AnaplanImportOperation.java
+++ b/src/main/java/com/anaplan/connector/utils/AnaplanImportOperation.java
@@ -64,7 +64,8 @@ public class AnaplanImportOperation extends BaseAnaplanOperation{
         }
 
         switch (columnSeparator) {
-            case ",":
+
+            case Delimiters.COMMA:
                 if (textDelimiter.isEmpty()) {
                     throw new AnaplanOperationException("Text-Delimiter " +
                             "needs to be specified!");
@@ -72,8 +73,10 @@ public class AnaplanImportOperation extends BaseAnaplanOperation{
                 return CSVFormat.RFC4180
                         .withDelimiter(columnSeparator.charAt(0))
                         .withQuote(textDelimiter.charAt(0));
-            case "\t":
+
+            case Delimiters.TAB:
                 return CSVFormat.TDF;
+
             default:
                 throw new AnaplanOperationException("Only commas and tabs are " +
                         "supported column-separators!");
@@ -98,7 +101,7 @@ public class AnaplanImportOperation extends BaseAnaplanOperation{
 	private static List<String[]> parseImportData(String data, String columnSeparator,
 	        String delimiter) throws AnaplanOperationException {
 
-        if (columnSeparator.length() > 1 && !columnSeparator.equals("\\t")) {
+        if (columnSeparator.length() > 1 && !columnSeparator.equals(Delimiters.TAB)) {
             throw new IllegalArgumentException(
                     "Multi-character Column-Separator not supported!");
         }

--- a/src/main/java/com/anaplan/connector/utils/AnaplanImportOperation.java
+++ b/src/main/java/com/anaplan/connector/utils/AnaplanImportOperation.java
@@ -57,14 +57,22 @@ public class AnaplanImportOperation extends BaseAnaplanOperation{
      */
     public static CSVFormat getCsvFormat(String columnSeparator, String textDelimiter)
             throws AnaplanOperationException {
+
+        if (columnSeparator.isEmpty()) {
+            throw new AnaplanOperationException("Column-Separator " +
+                    "needs to be specified!");
+        }
+
         switch (columnSeparator) {
             case ",":
+                if (textDelimiter.isEmpty()) {
+                    throw new AnaplanOperationException("Text-Delimiter " +
+                            "needs to be specified!");
+                }
                 return CSVFormat.RFC4180
                         .withDelimiter(columnSeparator.charAt(0))
                         .withQuote(textDelimiter.charAt(0));
-            // Mulesoft flow fails to run with \t, if you specify it in the
-            // properties file, so use \\t.
-            case "\\t":
+            case "\t":
                 return CSVFormat.TDF;
             default:
                 throw new AnaplanOperationException("Only commas and tabs are " +

--- a/src/main/java/com/anaplan/connector/utils/AnaplanImportOperation.java
+++ b/src/main/java/com/anaplan/connector/utils/AnaplanImportOperation.java
@@ -142,7 +142,7 @@ public class AnaplanImportOperation extends BaseAnaplanOperation{
 	 */
 	private static MulesoftAnaplanResponse runImportCsv(String data,
                                                         Model model,
-			                                            String importId,
+                                                        String importId,
                                                         String columnSeparator,
                                                         String delimiter,
                                                         String logContext)
@@ -245,7 +245,7 @@ public class AnaplanImportOperation extends BaseAnaplanOperation{
 	public String runImport(String data,
                             String workspaceId,
                             String modelId,
-			                String importId,
+                            String importId,
                             String columnSeparator,
                             String delimiter) throws AnaplanOperationException {
 

--- a/src/main/java/com/anaplan/connector/utils/AnaplanUtil.java
+++ b/src/main/java/com/anaplan/connector/utils/AnaplanUtil.java
@@ -39,10 +39,11 @@ public class AnaplanUtil {
      * @param toprint Data array to create debug string with.
      * @return Debug output for provided string array.
      */
-    public static String debug_output(String[] toprint) {
+    public static String debugOutput(String[] toprint) {
         StringBuilder sb = new StringBuilder();
         for (String s : toprint) {
-            sb.append(s + "||");
+            sb.append(s);
+            sb.append("||");
         }
         if (sb.length() > 1) {
             return sb.toString().substring(0, sb.length() - 1);

--- a/src/main/java/com/anaplan/connector/utils/Delimiters.java
+++ b/src/main/java/com/anaplan/connector/utils/Delimiters.java
@@ -1,0 +1,11 @@
+package com.anaplan.connector.utils;
+
+/**
+ * Created by spondonsaha on 1/7/16.
+ */
+public final class Delimiters {
+
+    public static final String COMMA = ",";
+    public static final String TAB = "\t";
+    public static final String ESCAPE_CHARACTER = "\"";
+}

--- a/src/main/java/com/anaplan/connector/utils/Delimiters.java
+++ b/src/main/java/com/anaplan/connector/utils/Delimiters.java
@@ -1,7 +1,8 @@
 package com.anaplan.connector.utils;
 
+
 /**
- * Created by spondonsaha on 1/7/16.
+ * Delimiter constants.
  */
 public final class Delimiters {
 


### PR DESCRIPTION
- Added support for CSVFormat.TDF format for the CSVParser implementation of parsing the data to be Imported, so now TSVs and CSVs can be parsed effectively. 
- Tested the change with both TSVs and CSVs using the same Export definition, originally defined by doing a CSV file-upload from the Anaplan UI.