### PR TITLE
bug/INTEGRA-718: Mulesoft uses \t as text delimiter instead of comma for CSV file

### DIFF
--- a/src/main/java/com/anaplan/connector/utils/Delimiters.java
+++ b/src/main/java/com/anaplan/connector/utils/Delimiters.java
@@ -7,6 +7,6 @@ package com.anaplan.connector.utils;
 public final class Delimiters {
 
     public static final String COMMA = ",";
-    public static final String TAB = "\t";
+    public static final String TAB = "\\t";
     public static final String ESCAPE_CHARACTER = "\"";
 }


### PR DESCRIPTION
Changed TAB delimiter to \\t, instead of \t, which was breaking Mulesoft Devkit if used in properties file.