### PR TITLE
feature/INTEGRA-921: Updated Mulseoft code with bug/INTEGRA-915 fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.mule.modules</groupId>
     <artifactId>anaplan-connector</artifactId>
-    <version>1.1.3</version>
+    <version>1.1.4</version>
     <packaging>mule-module</packaging>
     <name>Mulesoft Anaplan Connector</name>
 

--- a/src/main/java/com/anaplan/connector/utils/AnaplanImportOperation.java
+++ b/src/main/java/com/anaplan/connector/utils/AnaplanImportOperation.java
@@ -88,7 +88,6 @@ public class AnaplanImportOperation extends BaseAnaplanOperation{
 		}
 
 		ServerFile serverFile;
-		int chunkPointer = 0;
         try {
             serverFile = model.getServerFile(imp.getSourceFileId());
             if (serverFile == null) {
@@ -102,19 +101,11 @@ public class AnaplanImportOperation extends BaseAnaplanOperation{
 			OutputStream uploadStream = serverFile.getUploadStream();
 			Iterator<String> iterator = AnaplanUtil.stringChunkReader(data);
 			byte[] dataChunk;
-			int counter = 0;
 			while (iterator.hasNext()) {
 				dataChunk = iterator.next().getBytes("UTF-8");
 				uploadStream.write(dataChunk);
-				// TODO: Gets an almost accurate row-count, using a regex.
-				// Needs to be ultimately replaced with count returned from server.
-				chunkPointer += AnaplanUtil.getCarriageReturnCount(dataChunk);
-				//TODO: Remove later
-				counter++;
 			}
 			uploadStream.close();
-			logger.info("Approx. # of processed rows from stream chunks: {}",
-					chunkPointer);
 
         } catch (AnaplanAPIException | IOException e) {
             throw new AnaplanOperationException("Error encountered while " +
@@ -132,9 +123,8 @@ public class AnaplanImportOperation extends BaseAnaplanOperation{
             throw new AnaplanOperationException("Error running Import action:", e);
         }
 
-        String taskDetailsMsg = collectTaskLogs(status) +
-                "Import completed successfully: (" + chunkPointer +
-                " records processed)";
+		// 3. Get task status details and fetch the row counts
+        String taskDetailsMsg = collectTaskLogs(status);
 		setRunStatusDetails(taskDetailsMsg);
 		logger.info(getRunStatusDetails());
 

--- a/src/main/java/com/anaplan/connector/utils/AnaplanImportOperation.java
+++ b/src/main/java/com/anaplan/connector/utils/AnaplanImportOperation.java
@@ -18,7 +18,6 @@ package com.anaplan.connector.utils;
 
 
 import com.anaplan.client.AnaplanAPIException;
-import com.anaplan.client.CellWriter;
 import com.anaplan.client.Import;
 import com.anaplan.client.Model;
 import com.anaplan.client.ServerFile;
@@ -29,17 +28,13 @@ import com.anaplan.connector.MulesoftAnaplanResponse;
 import com.anaplan.connector.connection.AnaplanConnection;
 import com.anaplan.connector.exceptions.AnaplanOperationException;
 import com.google.gson.JsonSyntaxException;
-import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVParser;
-import org.apache.commons.csv.CSVRecord;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.text.MessageFormat;
-import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.List;
 
 
 /**
@@ -54,91 +49,6 @@ public class AnaplanImportOperation extends BaseAnaplanOperation{
 
 	public AnaplanImportOperation(AnaplanConnection apiConn) {
 		super(apiConn);
-	}
-
-    /**
-     * Determine the appropriate CSVFormat to be used based on provided
-     * column-separator and delimiter.
-     * @return CSVFormat.RFC4180 or CSVFormat.TDF.
-     */
-    public static CSVFormat getCsvFormat(String columnSeparator, String textDelimiter)
-            throws AnaplanOperationException {
-
-        if (columnSeparator.isEmpty()) {
-            throw new AnaplanOperationException("Column-Separator " +
-                    "needs to be specified!");
-        }
-
-        switch (columnSeparator) {
-
-            case Delimiters.COMMA:
-                if (textDelimiter.isEmpty()) {
-                    throw new AnaplanOperationException("Text-Delimiter " +
-                            "needs to be specified!");
-                }
-                return CSVFormat.RFC4180
-                        .withDelimiter(columnSeparator.charAt(0))
-                        .withQuote(textDelimiter.charAt(0));
-
-            case Delimiters.TAB:
-                return CSVFormat.TDF;
-
-            default:
-                throw new AnaplanOperationException("Only commas and tabs are " +
-                        "supported column-separators!");
-        }
-
-    }
-
-	/**
-	 * Import Data Parser: splits import data by new-lines, then for each row,
-	 * splits by the provided column-separator and escape delimiter.
-	 *
-	 * @param data
-     *              Data String.
-	 * @param columnSeparator
-     *              Column separator character.
-	 * @return
-     *              Array of rows properly escaped.
-	 * @throws AnaplanOperationException
-     *              To capture any exception when reading in data to buffered
-     *              reader object.
-	 */
-	private static List<String[]> parseImportData(String data, String columnSeparator,
-	        String delimiter) throws AnaplanOperationException {
-
-        if (columnSeparator.length() > 1 && !columnSeparator.equals(Delimiters.TAB)) {
-            throw new IllegalArgumentException(
-                    "Multi-character Column-Separator not supported!");
-        }
-
-        if (delimiter.length() > 1) {
-            throw new IllegalArgumentException("Multi-character Text Delimiter "
-                    + "string not supported!");
-        }
-
-        CSVFormat csvFormat = getCsvFormat(columnSeparator, delimiter);
-        String[] cellTokens;
-        List<String[]> rows = new ArrayList<>();
-        CSVParser csvParser;
-
-        try {
-            csvParser = CSVParser.parse(data, csvFormat);
-            int cellIdx;
-            for (CSVRecord record : csvParser.getRecords()) {
-                Iterator<String> cellIter = record.iterator();
-                cellTokens = new String[record.size()];
-                cellIdx = 0;
-                while (cellIter.hasNext()) {
-                    cellTokens[cellIdx++] = cellIter.next();
-                }
-                rows.add(cellTokens);
-            }
-        } catch (IOException e) {
-            throw new AnaplanOperationException("Error parsing data:", e);
-        }
-
-        return rows;
 	}
 
 	/**
@@ -166,8 +76,6 @@ public class AnaplanImportOperation extends BaseAnaplanOperation{
 
 		// 1. Write the provided CSV data to the data-writer.
 
-		int rowsProcessed = 0;
-
         Import imp;
         try {
             imp = model.getImport(importId);
@@ -180,6 +88,7 @@ public class AnaplanImportOperation extends BaseAnaplanOperation{
 		}
 
 		ServerFile serverFile;
+		int chunkPointer = 0;
         try {
             serverFile = model.getServerFile(imp.getSourceFileId());
             if (serverFile == null) {
@@ -189,21 +98,24 @@ public class AnaplanImportOperation extends BaseAnaplanOperation{
             serverFile.setSeparator(columnSeparator);
             serverFile.setDelimiter(delimiter);
 
-            List<String[]> rows = parseImportData(data, columnSeparator,
-                    delimiter);
+			// upload the data file as a stream
+			OutputStream uploadStream = serverFile.getUploadStream();
+			Iterator<String> iterator = AnaplanUtil.stringChunkReader(data);
+			byte[] dataChunk;
+			int counter = 0;
+			while (iterator.hasNext()) {
+				dataChunk = iterator.next().getBytes("UTF-8");
+				uploadStream.write(dataChunk);
+				// TODO: Gets an almost accurate row-count, using a regex.
+				// Needs to be ultimately replaced with count returned from server.
+				chunkPointer += AnaplanUtil.getCarriageReturnCount(dataChunk);
+				//TODO: Remove later
+				counter++;
+			}
+			uploadStream.close();
+			logger.info("Approx. # of processed rows from stream chunks: {}",
+					chunkPointer);
 
-            // get the data-writer and write data to it, i.e. serverFile by
-            // reference
-            final CellWriter dataWriter = serverFile.getUploadCellWriter();
-            dataWriter.writeHeaderRow(rows.get(0));
-            logger.info("import header is:\n{}", AnaplanUtil.debugOutput(
-                    rows.get(0)));
-
-            for (String[] row : rows) {
-                dataWriter.writeDataRow(row);
-                ++rowsProcessed;
-            }
-            dataWriter.close();
         } catch (AnaplanAPIException | IOException e) {
             throw new AnaplanOperationException("Error encountered while " +
                     "importing data: ", e);
@@ -221,7 +133,7 @@ public class AnaplanImportOperation extends BaseAnaplanOperation{
         }
 
         String taskDetailsMsg = collectTaskLogs(status) +
-                "Import completed successfully: (" + rowsProcessed +
+                "Import completed successfully: (" + chunkPointer +
                 " records processed)";
 		setRunStatusDetails(taskDetailsMsg);
 		logger.info(getRunStatusDetails());

--- a/src/main/java/com/anaplan/connector/utils/AnaplanUtil.java
+++ b/src/main/java/com/anaplan/connector/utils/AnaplanUtil.java
@@ -23,7 +23,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.Iterator;
-import java.util.regex.Pattern;
+import java.util.NoSuchElementException;
 
 
 /**
@@ -33,9 +33,8 @@ import java.util.regex.Pattern;
  */
 public class AnaplanUtil {
 
-    private static Logger logger = LogManager.getLogger(AnaplanUtil.class.getName());
+    private static final Logger logger = LogManager.getLogger(AnaplanUtil.class.getName());
     public static final int CHUNKSIZE = 2048;
-    public static final Pattern crPattern = Pattern.compile("(.+\r\n)|(.+\r)|(.+\n)");
 
     private AnaplanUtil() {
         // static-only
@@ -97,7 +96,6 @@ public class AnaplanUtil {
         return new Iterator<String>() {
 
             int index = 0;
-            String dataChunk;
 
             @Override
             public boolean hasNext() {
@@ -106,13 +104,14 @@ public class AnaplanUtil {
 
             @Override
             public String next() {
+                String dataChunk;
                 if (hasNext()) {
                     dataChunk = data.substring(index, Math.min(index + chunkSize,
                             data.length()));
                     index += chunkSize;
                     return dataChunk;
                 }
-                return null;
+                throw new NoSuchElementException("No more chunks to fetch!");
             }
 
             @Override

--- a/src/main/java/com/anaplan/connector/utils/AnaplanUtil.java
+++ b/src/main/java/com/anaplan/connector/utils/AnaplanUtil.java
@@ -23,7 +23,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.Iterator;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 
@@ -122,24 +121,5 @@ public class AnaplanUtil {
                         "Iterator not fail-safe!");
             }
         };
-    }
-
-
-    // TODO: Gets an almost accurate row-count, using a regex.
-    // Needs to be ultimately replaced with count returned from server.
-    /**
-     * Fetches the number of carriage-returns from each char-array, which can be
-     * cast as string.
-     * @param charArray Byte array of the string that needs to be introspected.
-     * @return number of carriage returns found in provided byte-array.
-     */
-    public static int getCarriageReturnCount(byte[] charArray) {
-
-        Matcher m = crPattern.matcher(new String(charArray));
-        int lines = 0;
-        while (m.find()) {
-            lines++;
-        }
-        return lines;
     }
 }

--- a/src/main/java/com/anaplan/connector/utils/AnaplanUtil.java
+++ b/src/main/java/com/anaplan/connector/utils/AnaplanUtil.java
@@ -22,6 +22,10 @@ import com.anaplan.client.TaskStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Iterator;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 
 /**
  * Utilities here handle communication with the Anaplan API
@@ -31,6 +35,8 @@ import org.apache.logging.log4j.Logger;
 public class AnaplanUtil {
 
     private static Logger logger = LogManager.getLogger(AnaplanUtil.class.getName());
+    public static final int CHUNKSIZE = 2048;
+    public static final Pattern crPattern = Pattern.compile("(.+\r\n)|(.+\r)|(.+\n)");
 
     private AnaplanUtil() {
         // static-only
@@ -82,5 +88,78 @@ public class AnaplanUtil {
         }
 
         return status;
+    }
+
+    /**
+     * Overloading for stringChunkReader(String, Integer).
+     *
+     * @param data
+     *            String data.
+     * @return
+     */
+    public static Iterator<String> stringChunkReader(final String data) {
+        return stringChunkReader(data, CHUNKSIZE);
+    }
+
+    /**
+     * Data splitter to be used in association with arrayToBase64(). Splits up
+     * the data by provided chunkSize value and returns an iterator to iterate
+     * over each chunk.
+     *
+     * @param data
+     *            Data string, base64 friendly.
+     * @param chunkSize
+     *            Chunk size limit, defaults to 2048 characters.
+     * @return Iterator to iterate over each data-chunk.
+     */
+    public static Iterator<String> stringChunkReader(final String data,
+                                                    final int chunkSize) {
+
+        return new Iterator<String>() {
+
+            int index = 0;
+            String dataChunk;
+
+            @Override
+            public boolean hasNext() {
+                return index < data.length();
+            }
+
+            @Override
+            public String next() {
+                if (hasNext()) {
+                    dataChunk = data.substring(index, Math.min(index + chunkSize,
+                            data.length()));
+                    index += chunkSize;
+                    return dataChunk;
+                }
+                return null;
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException(
+                        "Iterator not fail-safe!");
+            }
+        };
+    }
+
+
+    // TODO: Gets an almost accurate row-count, using a regex.
+    // Needs to be ultimately replaced with count returned from server.
+    /**
+     * Fetches the number of carriage-returns from each char-array, which can be
+     * cast as string.
+     * @param charArray Byte array of the string that needs to be introspected.
+     * @return number of carriage returns found in provided byte-array.
+     */
+    public static int getCarriageReturnCount(byte[] charArray) {
+
+        Matcher m = crPattern.matcher(new String(charArray));
+        int lines = 0;
+        while (m.find()) {
+            lines++;
+        }
+        return lines;
     }
 }

--- a/src/main/java/com/anaplan/connector/utils/AnaplanUtil.java
+++ b/src/main/java/com/anaplan/connector/utils/AnaplanUtil.java
@@ -43,26 +43,6 @@ public class AnaplanUtil {
     }
 
     /**
-     * Prints an array of strings as a string, delimited by "||". This is for
-     * debug logs only.
-     *
-     * @param toprint Data array to create debug string with.
-     * @return Debug output for provided string array.
-     */
-    public static String debugOutput(String[] toprint) {
-        StringBuilder sb = new StringBuilder();
-        for (String s : toprint) {
-            sb.append(s);
-            sb.append("||");
-        }
-        if (sb.length() > 1) {
-            return sb.toString().substring(0, sb.length() - 1);
-        } else {
-            return "*";
-        }
-    }
-
-    /**
      * Executes an Anaplan task and polls the status until its complete.
      *
      * @param task Server task object to run.

--- a/src/main/java/com/anaplan/connector/utils/AnaplanUtil.java
+++ b/src/main/java/com/anaplan/connector/utils/AnaplanUtil.java
@@ -60,7 +60,7 @@ public class AnaplanUtil {
             // if busy, nap and check again after 1 second
             try {
                 Thread.sleep(1000);
-                logger.debug("Running Task = {}", task.getStatus().getProgress());
+                logger.info("Running Task = {}", task.getStatus().getProgress());
             } catch (InterruptedException e) {
                 logger.error("Task interrupted!\n{}", e.getMessage());
             }

--- a/src/test/java/com/anaplan/connector/runner/UnitTestSuite.java
+++ b/src/test/java/com/anaplan/connector/runner/UnitTestSuite.java
@@ -1,12 +1,18 @@
 package com.anaplan.connector.runner;
 
-import com.anaplan.connector.unit.*;
+import com.anaplan.connector.unit.AnaplanUtilTestCases;
+import com.anaplan.connector.unit.ConnectionUnitTestCases;
+import com.anaplan.connector.unit.DeleteOperationUnitTestCases;
+import com.anaplan.connector.unit.ExportOperationUnitTestCases;
+import com.anaplan.connector.unit.ImportOperationUnitTestCases;
+import com.anaplan.connector.unit.ProcessOperationUnitTestCases;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 @RunWith(Suite.class)
 @SuiteClasses({
+		AnaplanUtilTestCases.class,
         ConnectionUnitTestCases.class,
         ImportOperationUnitTestCases.class,
         ExportOperationUnitTestCases.class,

--- a/src/test/java/com/anaplan/connector/unit/AnaplanUtilTestCases.java
+++ b/src/test/java/com/anaplan/connector/unit/AnaplanUtilTestCases.java
@@ -1,0 +1,62 @@
+package com.anaplan.connector.unit;
+
+
+import com.anaplan.client.Task;
+import com.anaplan.client.TaskStatus;
+import com.anaplan.connector.utils.AnaplanUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.junit.Assert.assertEquals;
+
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({
+		Task.class,
+		TaskStatus.class})
+public class AnaplanUtilTestCases {
+
+	private Task mockTask;
+	private TaskStatus mockTaskStatus;
+
+	@Before
+	public void setUp() {
+		mockTask = Mockito.mock(Task.class);
+		mockTaskStatus = Mockito.mock(TaskStatus.class);
+	}
+
+	@After
+	public void tearDown() {
+		mockTask = null;
+		mockTaskStatus = null;
+	}
+
+	@Test
+	public void testRunServerTask() throws Exception {
+		final int mockServerPingCountLimit = 4;
+		PowerMockito.doReturn(mockTaskStatus).when(mockTask).getStatus();
+		PowerMockito.doReturn(TaskStatus.State.IN_PROGRESS).when(mockTaskStatus)
+				.getTaskState();
+		Mockito.when(mockTaskStatus.getTaskState()).thenAnswer(new Answer() {
+			private int count = 0;
+
+			@Override
+			public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+				if (count++ < mockServerPingCountLimit)
+					return TaskStatus.State.IN_PROGRESS;
+				return TaskStatus.State.COMPLETE;
+			}
+		});
+
+		TaskStatus resultStatus = AnaplanUtil.runServerTask(mockTask);
+		assertEquals(mockTaskStatus, resultStatus);
+	}
+}

--- a/src/test/java/com/anaplan/connector/unit/ImportOperationUnitTestCases.java
+++ b/src/test/java/com/anaplan/connector/unit/ImportOperationUnitTestCases.java
@@ -71,8 +71,6 @@ public class ImportOperationUnitTestCases extends BaseUnitTestDriver {
 				.thenCallRealMethod();
 		PowerMockito.when(AnaplanUtil.stringChunkReader(Mockito.anyString(),
 				Mockito.anyInt())).thenCallRealMethod();
-		PowerMockito.when(AnaplanUtil.getCarriageReturnCount(
-				Mockito.any(byte[].class))).thenCallRealMethod();
 	}
 
     @Test


### PR DESCRIPTION
Fix that prevents the uploaded-file Data-Source definition from getting corrupted, and getting the column-separator hard-coded to <TAB>. Also, row-counts are now being fetched from the server, instead of relying on the client.