### PR TITLE
INTEGRA-941: BUG: Dump-file not present when Import fails

### DIFF
--- a/src/main/java/com/anaplan/connector/utils/AnaplanImportOperation.java
+++ b/src/main/java/com/anaplan/connector/utils/AnaplanImportOperation.java
@@ -174,23 +174,21 @@ public class AnaplanImportOperation extends BaseAnaplanOperation{
         // validate workspace-ID and model-ID are valid, else throw exception
         validateInput(workspaceId, modelId);
 
-        MulesoftAnaplanResponse anaplanResponse = null;
+        MulesoftAnaplanResponse anaplanResponse;
+        String importResponse = "";
         try {
             logger.info("Starting import: {}", importId);
-
             anaplanResponse = runImportCsv(data, model, importId, columnSeparator,
                     delimiter);
-
+            importResponse = createResponse(anaplanResponse);
             logger.info("Import complete: Status: {}, Response message: {}",
-                    anaplanResponse.getStatus(),
-                    anaplanResponse.getResponseMessage());
-
+                    anaplanResponse.getStatus(), importResponse);
         } catch (JsonSyntaxException e) {
             MulesoftAnaplanResponse.responseEpicFail(apiConn, e, null);
         } finally {
             apiConn.closeConnection();
         }
 
-        return createResponse(anaplanResponse);
+        return importResponse;
     }
 }

--- a/src/main/java/com/anaplan/connector/utils/BaseAnaplanOperation.java
+++ b/src/main/java/com/anaplan/connector/utils/BaseAnaplanOperation.java
@@ -216,7 +216,6 @@ public class BaseAnaplanOperation {
 				throw new AnaplanOperationException(
 						"Could not determine run status of " + "Anaplan Import!");
 		}
-		logger.info(responseMessage);
 		return responseMessage;
 	}
 }


### PR DESCRIPTION
Fix is to keep the API connection open until the Dump-file and any other
post-Import operations are completed, then close it gracefully.