### PR TITLE
bug/INTEGRA-962

### DIFF
--- a/demo/anaplan-import/src/main/app/anaplan-import.xml
+++ b/demo/anaplan-import/src/main/app/anaplan-import.xml
@@ -12,6 +12,6 @@ http://www.mulesoft.org/schema/mule/ee/tracking http://www.mulesoft.org/schema/m
     <file:connector name="File" readFromDirectory="${file.readFromDir}" autoDelete="true" streaming="true" validateConnections="true" doc:name="File"/>
     <flow name="anaplan-importFlow">
         <file:inbound-endpoint path="${file.readFromDir}" moveToDirectory="${file.moveToDir}" connector-ref="File" responseTimeout="10000" doc:name="File"/>
-        <anaplan:import-to-model config-ref="Anaplan__Certificate_Authentication" importId="${anaplan.importId}" modelId="${anaplan.modelId}" workspaceId="${anaplan.workspaceId}" doc:name="Anaplan" columnSeparator="${anaplan.columnSeparator}" delimiter="${anaplan.delimiter}"/>
+        <anaplan:import-to-model config-ref="Anaplan__Certificate_Authentication" importId="${anaplan.importId}" modelId="${anaplan.modelId}" workspaceId="${anaplan.workspaceId}" doc:name="Anaplan"/>
     </flow>
 </mule>

--- a/demo/anaplan-import/src/main/app/mule-app.properties
+++ b/demo/anaplan-import/src/main/app/mule-app.properties
@@ -7,8 +7,5 @@ anaplan.workspaceId=
 anaplan.modelId=
 anaplan.importId=
 
-anaplan.columnSeparator=,
-anaplan.delimiter="
-
 file.readFromDir=
 file.moveToDir=

--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,7 @@
                             <include>com/anaplan/connector/MulesoftAnaplanResponse.class</include>
                         </includes>
                     </instrumentation>
+                    <check/>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/com/anaplan/connector/AnaplanConnector.java
+++ b/src/main/java/com/anaplan/connector/AnaplanConnector.java
@@ -24,12 +24,10 @@ import com.anaplan.connector.utils.AnaplanDeleteOperation;
 import com.anaplan.connector.utils.AnaplanExportOperation;
 import com.anaplan.connector.utils.AnaplanImportOperation;
 import com.anaplan.connector.utils.AnaplanProcessOperation;
-import com.anaplan.connector.utils.Delimiters;
 import org.mule.api.annotations.Config;
 import org.mule.api.annotations.Connector;
 import org.mule.api.annotations.Processor;
 import org.mule.api.annotations.display.FriendlyName;
-import org.mule.api.annotations.param.Default;
 import org.mule.api.annotations.param.Payload;
 
 
@@ -78,8 +76,6 @@ public class AnaplanConnector {
      * @param workspaceId Anaplan workspace ID.
      * @param modelId Anaplan model ID.
      * @param importId Action ID of the Import operation.
-     * @param columnSeparator Column separator, defaults to comma.
-     * @param delimiter Cell escape values, defaults to double-quotes.
      * @return Status message from running the Import operation.
      * @throws AnaplanConnectionException When an error occurs during
      * 									  authentication
@@ -91,11 +87,7 @@ public class AnaplanConnector {
 			@Payload String data,
 			@FriendlyName("Workspace name or ID") String workspaceId,
 		    @FriendlyName("Model name or ID") String modelId,
-		    @FriendlyName("Import name or ID") String importId,
-			@FriendlyName("Column separator")
-			@Default(Delimiters.COMMA) String columnSeparator,
-			@FriendlyName("Delimiter")
-			@Default(Delimiters.ESCAPE_CHARACTER) String delimiter)
+		    @FriendlyName("Import name or ID") String importId)
 		    		throws AnaplanConnectionException,
 		    			   AnaplanOperationException {
 		// validate API connectionStrategy
@@ -104,8 +96,7 @@ public class AnaplanConnector {
 		// start the import
 		importer = new AnaplanImportOperation(
 				connectionStrategy.getApiConnection());
-		return importer.runImport(data, workspaceId, modelId, importId,
-				columnSeparator, delimiter);
+		return importer.runImport(data, workspaceId, modelId, importId);
 	}
 
 	/**

--- a/src/main/java/com/anaplan/connector/utils/AnaplanImportOperation.java
+++ b/src/main/java/com/anaplan/connector/utils/AnaplanImportOperation.java
@@ -62,16 +62,13 @@ public class AnaplanImportOperation extends BaseAnaplanOperation{
      * @param data Import CSV data
      * @param model Model object to which to import to
      * @param importId Import action ID
-     * @param delimiter Escape character for cell values.
      * @throws AnaplanAPIException Thrown when Anaplan API operation fails or
      *                             error is encountered when writing to
      *                             cell data writer.
      */
     private static MulesoftAnaplanResponse runImportCsv(String data,
                                                         Model model,
-                                                        String importId,
-                                                        String columnSeparator,
-                                                        String delimiter)
+                                                        String importId)
             throws AnaplanOperationException {
 
         // 1. Write the provided CSV data to the data-writer.
@@ -93,9 +90,6 @@ public class AnaplanImportOperation extends BaseAnaplanOperation{
             if (serverFile == null) {
                 throw new AnaplanOperationException("Could not fetch server-file!");
             }
-            // set the column-separator and delimiter for the input
-            serverFile.setSeparator(columnSeparator);
-            serverFile.setDelimiter(delimiter);
 
             // upload the data file as a stream
             OutputStream uploadStream = serverFile.getUploadStream();
@@ -162,9 +156,7 @@ public class AnaplanImportOperation extends BaseAnaplanOperation{
     public String runImport(String data,
                             String workspaceId,
                             String modelId,
-                            String importId,
-                            String columnSeparator,
-                            String delimiter) throws AnaplanOperationException {
+                            String importId) throws AnaplanOperationException {
 
         logger.info("<< Starting import >>");
         logger.info("Workspace-ID: {}", workspaceId);
@@ -178,8 +170,7 @@ public class AnaplanImportOperation extends BaseAnaplanOperation{
         String importResponse = "";
         try {
             logger.info("Starting import: {}", importId);
-            anaplanResponse = runImportCsv(data, model, importId, columnSeparator,
-                    delimiter);
+            anaplanResponse = runImportCsv(data, model, importId);
             importResponse = createResponse(anaplanResponse);
             logger.info("Import complete: Status: {}, Response message: {}",
                     anaplanResponse.getStatus(), importResponse);

--- a/src/test/java/com/anaplan/connector/unit/ImportOperationUnitTestCases.java
+++ b/src/test/java/com/anaplan/connector/unit/ImportOperationUnitTestCases.java
@@ -25,10 +25,6 @@ public class ImportOperationUnitTestCases extends BaseUnitTestDriver {
 
     private static final String importId = properties.getString(
             "anaplan.importId");
-    private static final String csvColumnSeparator = properties.getString(
-            "anaplan.columnSeparatorCOMMA");
-    private static final String csvDelimiter = properties.getString(
-            "anaplan.delimiter");
     private static final String importUrlPathToken = properties.getString(
             "import.urlPathToken");
 	private static final String dumpFileUrlPathToken = properties.getString(
@@ -84,7 +80,7 @@ public class ImportOperationUnitTestCases extends BaseUnitTestDriver {
 		recordActionsStrinkChunkReader();
 
         anaplanImportOperation.runImport(sampleDataFile, workspaceId, modelId,
-                importId, csvColumnSeparator, csvDelimiter);
+                importId);
     }
 
 	private void recordActionsImportTaskResultFailureDump() throws Exception {
@@ -111,7 +107,7 @@ public class ImportOperationUnitTestCases extends BaseUnitTestDriver {
 		recordActionsImportTaskResultFailureDump();
 
 		String response = anaplanImportOperation.runImport(sampleDataFile,
-				workspaceId, modelId, importId, csvColumnSeparator, csvDelimiter);
+				workspaceId, modelId, importId);
 		String expectedResponseMsg = "Operation ran successfully but with warnings!\n" +
 				"Response Message:\nSome records were not imported: check " +
 				"connector output data for details: importId\nDump File " +
@@ -129,7 +125,7 @@ public class ImportOperationUnitTestCases extends BaseUnitTestDriver {
         expectedEx.expectMessage("Error fetching Import action:");
 
         anaplanImportOperation.runImport(sampleDataFile, workspaceId, modelId,
-                importId, csvColumnSeparator, csvDelimiter);
+                importId);
     }
 
     @Test
@@ -143,8 +139,7 @@ public class ImportOperationUnitTestCases extends BaseUnitTestDriver {
         expectedEx.expectMessage("Invalid import ID provided: badImportId");
 
         anaplanImportOperation.runImport(sampleDataFile,
-                workspaceId, modelId, "badImportId", csvColumnSeparator,
-                csvDelimiter);
+                workspaceId, modelId, "badImportId");
     }
 
     @Test
@@ -159,7 +154,7 @@ public class ImportOperationUnitTestCases extends BaseUnitTestDriver {
         expectedEx.expectMessage("Error running Import action:");
 
         anaplanImportOperation.runImport(sampleDataFile, workspaceId, modelId,
-                importId, csvColumnSeparator, csvDelimiter);
+                importId);
     }
 
 }

--- a/src/test/resources/test.properties
+++ b/src/test/resources/test.properties
@@ -8,10 +8,6 @@ anaplan.exportId=exportId
 anaplan.processId=processId
 anaplan.deleteId=deleteId
 
-anaplan.columnSeparatorCOMMA=,
-anaplan.columnSeparatorTAB=\\t
-anaplan.delimiter="
-
 workspace.urlPathToken=/1/3/workspaces/
 model.urlPathToken=/1/3/workspaces/testWorkspaceNameOrId/models/testModelNameOrId
 import.urlPathToken=/1/3/workspaces/testWorkspaceNameOrId/models/testModelNameOrId/imports/importId


### PR DESCRIPTION
Removed column-separator/delimiter fields from Connector project, as well as demo projects. Tested the connector via installing and running a few Imports: for good imports, completes successfully; for bad imports, throws an exception and displays the error-message from server (when trying to import a TSV for a Data-source definition that has a CSV)