### PR TITLE
feature/INTEGRA-1024

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.mule.modules</groupId>
     <artifactId>anaplan-connector</artifactId>
-    <version>1.1.4</version>
+    <version>1.1.5</version>
     <packaging>mule-module</packaging>
     <name>Mulesoft Anaplan Connector</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,18 @@
                     <check/>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <configuration>
+                    <failFast>true</failFast>
+                    <rules>
+                        <requireJavaVersion>
+                            <version>[1.7,)</version>
+                        </requireJavaVersion>
+                    </rules>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/src/main/java/com/anaplan/connector/AnaplanConnector.java
+++ b/src/main/java/com/anaplan/connector/AnaplanConnector.java
@@ -40,14 +40,8 @@ import java.io.InputStream;
  * @author MuleSoft, Inc.
  * @author Spondon Saha.
  */
-@Connector(name="anaplan", schemaVersion="3.6", friendlyName="Anaplan",
-           minMuleVersion="3.6")
+@Connector(name="anaplan", schemaVersion="3.6", friendlyName="Anaplan", minMuleVersion="3.6")
 public class AnaplanConnector {
-
-	private static AnaplanExportOperation exporter;
-	private static AnaplanImportOperation importer;
-	private static AnaplanDeleteOperation deleter;
-	private static AnaplanProcessOperation processRunner;
 
 	@Config
 	private BaseConnectionStrategy connectionStrategy;
@@ -89,17 +83,16 @@ public class AnaplanConnector {
 		@Payload InputStream data,
 		@FriendlyName("Workspace Name or ID") String workspaceId,
 		@FriendlyName("Model Name or ID") String modelId,
-		@FriendlyName("Import Name or ID") String importId,
-		@FriendlyName("Import Buffer Size:") Integer bufferSize)
+		@FriendlyName("Import Name or ID") String importId)
 			throws AnaplanConnectionException,
 				   AnaplanOperationException {
 		// validate API connectionStrategy
 		connectionStrategy.validateConnection();
 
 		// start the import
-		importer = new AnaplanImportOperation(
-				connectionStrategy.getApiConnection());
-		return importer.runImport(data, workspaceId, modelId, importId, bufferSize);
+		AnaplanImportOperation importer = new AnaplanImportOperation(
+			connectionStrategy.getApiConnection());
+		return importer.runImport(data, workspaceId, modelId, importId, null);
 	}
 
 	/**
@@ -129,8 +122,8 @@ public class AnaplanConnector {
 		connectionStrategy.validateConnection();
 
 		// start the export
-		exporter = new AnaplanExportOperation(
-				connectionStrategy.getApiConnection());
+		AnaplanExportOperation exporter = new AnaplanExportOperation(
+			connectionStrategy.getApiConnection());
 		return exporter.runExport(workspaceId, modelId, exportId);
 	}
 
@@ -158,8 +151,8 @@ public class AnaplanConnector {
 		connectionStrategy.validateConnection();
 
 		// start the delete process
-		deleter = new AnaplanDeleteOperation(
-				connectionStrategy.getApiConnection());
+		AnaplanDeleteOperation deleter = new AnaplanDeleteOperation(
+			connectionStrategy.getApiConnection());
 		return deleter.runDeleteAction(workspaceId, modelId, deleteActionId);
 	}
 
@@ -188,8 +181,8 @@ public class AnaplanConnector {
 		connectionStrategy.validateConnection();
 
 		// run the process
-		processRunner = new AnaplanProcessOperation(
-				connectionStrategy.getApiConnection());
+		AnaplanProcessOperation processRunner = new AnaplanProcessOperation(
+			connectionStrategy.getApiConnection());
 		return processRunner.runProcess(workspaceId, modelId, processId);
 
 	}

--- a/src/main/java/com/anaplan/connector/AnaplanConnector.java
+++ b/src/main/java/com/anaplan/connector/AnaplanConnector.java
@@ -30,6 +30,8 @@ import org.mule.api.annotations.Processor;
 import org.mule.api.annotations.display.FriendlyName;
 import org.mule.api.annotations.param.Payload;
 
+import java.io.InputStream;
+
 
 /**
  * Anaplan Connector that supports Anaplan actions such as Import, Export,
@@ -84,19 +86,20 @@ public class AnaplanConnector {
      */
 	@Processor(friendlyName = "Import")
 	public String importToModel(
-			@Payload String data,
-			@FriendlyName("Workspace name or ID") String workspaceId,
-		    @FriendlyName("Model name or ID") String modelId,
-		    @FriendlyName("Import name or ID") String importId)
-		    		throws AnaplanConnectionException,
-		    			   AnaplanOperationException {
+		@Payload InputStream data,
+		@FriendlyName("Workspace Name or ID") String workspaceId,
+		@FriendlyName("Model Name or ID") String modelId,
+		@FriendlyName("Import Name or ID") String importId,
+		@FriendlyName("Import Buffer Size:") Integer bufferSize)
+			throws AnaplanConnectionException,
+				   AnaplanOperationException {
 		// validate API connectionStrategy
 		connectionStrategy.validateConnection();
 
 		// start the import
 		importer = new AnaplanImportOperation(
 				connectionStrategy.getApiConnection());
-		return importer.runImport(data, workspaceId, modelId, importId);
+		return importer.runImport(data, workspaceId, modelId, importId, bufferSize);
 	}
 
 	/**
@@ -117,11 +120,11 @@ public class AnaplanConnector {
 	 */
 	@Processor(friendlyName="Export")
 	public String exportFromModel(
-			@FriendlyName("Workspace name or ID") String workspaceId,
-			@FriendlyName("Model name or ID") String modelId,
-			@FriendlyName("Export name or ID") String exportId)
-					throws AnaplanConnectionException,
-						   AnaplanOperationException {
+		@FriendlyName("Workspace name or ID") String workspaceId,
+		@FriendlyName("Model name or ID") String modelId,
+		@FriendlyName("Export name or ID") String exportId)
+			throws AnaplanConnectionException,
+				   AnaplanOperationException {
 		// validate API connectionStrategy
 		connectionStrategy.validateConnection();
 
@@ -146,11 +149,11 @@ public class AnaplanConnector {
 	 */
 	@Processor(friendlyName="Delete")
 	public String deleteFromModel(
-			@FriendlyName("Workspace name or ID") String workspaceId,
-			@FriendlyName("Model name or ID") String modelId,
-			@FriendlyName("Delete action name or ID") String deleteActionId)
-					throws AnaplanConnectionException,
-						   AnaplanOperationException {
+		@FriendlyName("Workspace name or ID") String workspaceId,
+		@FriendlyName("Model name or ID") String modelId,
+		@FriendlyName("Delete action name or ID") String deleteActionId)
+			throws AnaplanConnectionException,
+				   AnaplanOperationException {
 		// validate the API connectionStrategy
 		connectionStrategy.validateConnection();
 
@@ -176,11 +179,11 @@ public class AnaplanConnector {
 	 */
 	@Processor(friendlyName="Process")
 	public String runProcess(
-			@FriendlyName("Workspace name or ID") String workspaceId,
-			@FriendlyName("Model name or ID") String modelId,
-			@FriendlyName("Process name or ID") String processId)
-					throws AnaplanConnectionException,
-						   AnaplanOperationException {
+		@FriendlyName("Workspace name or ID") String workspaceId,
+		@FriendlyName("Model name or ID") String modelId,
+		@FriendlyName("Process name or ID") String processId)
+			throws AnaplanConnectionException,
+				   AnaplanOperationException {
 		// validate the API connectionStrategy
 		connectionStrategy.validateConnection();
 

--- a/src/main/java/com/anaplan/connector/utils/AnaplanDeleteOperation.java
+++ b/src/main/java/com/anaplan/connector/utils/AnaplanDeleteOperation.java
@@ -57,7 +57,7 @@ public class AnaplanDeleteOperation extends BaseAnaplanOperation {
 	 * @return Response object containing details of executing delete.
 	 * @throws AnaplanAPIException Thrown when errors at talkng to API.
 	 */
-	private static MulesoftAnaplanResponse runDeleteAction(Model model,
+	private MulesoftAnaplanResponse runDeleteAction(Model model,
 			String actionId) throws AnaplanAPIException {
 
 		final Action action = model.getAction(actionId);

--- a/src/main/java/com/anaplan/connector/utils/AnaplanExportOperation.java
+++ b/src/main/java/com/anaplan/connector/utils/AnaplanExportOperation.java
@@ -61,7 +61,7 @@ public class AnaplanExportOperation extends BaseAnaplanOperation {
 	 * @throws AnaplanAPIException Thrown when error creating export task, or
 	 *                             running it, or when building the response
 	 */
-	private static MulesoftAnaplanResponse doExport(Model model, String exportId)
+	private MulesoftAnaplanResponse doExport(Model model, String exportId)
 			throws AnaplanOperationException {
 
 		Export exp;

--- a/src/main/java/com/anaplan/connector/utils/AnaplanImportOperation.java
+++ b/src/main/java/com/anaplan/connector/utils/AnaplanImportOperation.java
@@ -116,6 +116,8 @@ public class AnaplanImportOperation extends BaseAnaplanOperation{
                 throw new AnaplanOperationException("Could not fetch server-file!");
             }
 
+            logger.info("Uploading file...");
+
             // upload the data file from one stream to the other, in provided bufferSize
             OutputStream anaplanUploadStream = getServerFile().getUploadStream();
             byte[] buffer = new byte[bufferSize];
@@ -130,10 +132,11 @@ public class AnaplanImportOperation extends BaseAnaplanOperation{
                     totalBytes += bufferSize;
                 }
             }
-            anaplanUploadStream.close();
-            dataStream.close();
 
             logger.info("Uploaded '{}' bytes of data!", totalBytes);
+
+            anaplanUploadStream.close();
+            dataStream.close();  // triggers deletion of source file in Inbound File connector
 
         } catch (AnaplanAPIException | IOException e) {
             throw new AnaplanOperationException("Error encountered while " +

--- a/src/main/java/com/anaplan/connector/utils/AnaplanImportOperation.java
+++ b/src/main/java/com/anaplan/connector/utils/AnaplanImportOperation.java
@@ -143,6 +143,12 @@ public class AnaplanImportOperation extends BaseAnaplanOperation{
         return this;
     }
 
+    /**
+     * Executes an Import action for the provided Import-ID
+     * @param importId
+     * @return
+     * @throws AnaplanOperationException
+     */
     public AnaplanImportOperation runImportTask(String importId) throws AnaplanOperationException {
 
         Task task;

--- a/src/main/java/com/anaplan/connector/utils/AnaplanImportOperation.java
+++ b/src/main/java/com/anaplan/connector/utils/AnaplanImportOperation.java
@@ -32,9 +32,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.text.MessageFormat;
-import java.util.Iterator;
 
 
 /**
@@ -47,77 +47,114 @@ public class AnaplanImportOperation extends BaseAnaplanOperation{
     private static Logger logger = LogManager.getLogger(
             AnaplanImportOperation.class.getName());
 
+    private Import importService;
+    private ServerFile serverFile;
+    private MulesoftAnaplanResponse response;
+
     public AnaplanImportOperation(AnaplanConnection apiConn) {
         super(apiConn);
     }
 
+    public MulesoftAnaplanResponse getResponse() {
+        return response;
+    }
+
+    public Import getImportService() {
+        return importService;
+    }
+
+    public ServerFile getServerFile() {
+        return serverFile;
+    }
+
+    public void setImportService(Import importService) {
+        this.importService = importService;
+    }
+
+    public void setServerFile(ServerFile serverFile) {
+        this.serverFile = serverFile;
+    }
+
+    public void setResponse(MulesoftAnaplanResponse response) {
+        this.response = response;
+    }
+
     /**
-     * Core method to run the Import operation. Expects data as a string-ified
-     * CSV, parses the data based on provided column-separator and delimiter,
-     * creates an import action based on Model provided, writes the provided
-     * data to the action object, executes the action on the server and
-     * monitor's the status until the import completes successfully and responds
-     * the status (failed/succeeded) via an AnaplanResponse object.
+     * Uploads contents of dataStream, for the Serverfile for the provided
+     * Import-ID and Model-ID.
      *
-     * @param data Import CSV data
+     * @param dataStream Import data
      * @param model Model object to which to import to
      * @param importId Import action ID
      * @throws AnaplanAPIException Thrown when Anaplan API operation fails or
      *                             error is encountered when writing to
      *                             cell data writer.
      */
-    private static MulesoftAnaplanResponse runImportCsv(String data,
-                                                        Model model,
-                                                        String importId)
+    private AnaplanImportOperation upload(InputStream dataStream,
+                                          Model model, String importId,
+                                          Integer bufferSize)
             throws AnaplanOperationException {
 
-        // 1. Write the provided CSV data to the data-writer.
+        // defaults to 1MB
+        bufferSize = (bufferSize == null) ? 1048576 : bufferSize;
 
-        Import imp;
+        // Get the Import object, then use that to fetch the ServerFile, from
+        // the Model, that will help create the upload-stream
         try {
-            imp = model.getImport(importId);
+            setImportService(model.getImport(importId));
         } catch (AnaplanAPIException e) {
             throw new AnaplanOperationException("Error fetching Import action:", e);
         }
-        if (imp == null) {
+        if (getImportService() == null) {
             throw new AnaplanOperationException(MessageFormat.format("Invalid " +
                     "import ID provided: {0}", importId));
         }
 
-        ServerFile serverFile;
         try {
-            serverFile = model.getServerFile(imp.getSourceFileId());
-            if (serverFile == null) {
+            setServerFile(model.getServerFile(getImportService().getSourceFileId()));
+            if (getServerFile() == null) {
                 throw new AnaplanOperationException("Could not fetch server-file!");
             }
 
-            // upload the data file as a stream
-            OutputStream uploadStream = serverFile.getUploadStream();
-            Iterator<String> iterator = AnaplanUtil.stringChunkReader(data);
-            byte[] dataChunk;
-            while (iterator.hasNext()) {
-                dataChunk = iterator.next().getBytes("UTF-8");
-                uploadStream.write(dataChunk);
+            // upload the data file from one stream to the other, in provided bufferSize
+            OutputStream anaplanUploadStream = getServerFile().getUploadStream();
+            byte[] buffer = new byte[bufferSize];
+            int len;
+            int totalBytes = 0;
+            while ((len = dataStream.read(buffer)) != -1) {
+                if (len < bufferSize) {
+                    anaplanUploadStream.write(buffer, 0, len);
+                    totalBytes += len;
+                } else {
+                    anaplanUploadStream.write(buffer);
+                    totalBytes += bufferSize;
+                }
             }
-            uploadStream.close();
+            anaplanUploadStream.close();
+            dataStream.close();
+
+            logger.info("Uploaded '{}' bytes of data!", totalBytes);
 
         } catch (AnaplanAPIException | IOException e) {
             throw new AnaplanOperationException("Error encountered while " +
                     "importing data: ", e);
         }
 
-        // 2. Create the task that will import the data to the server.
+        return this;
+    }
+
+    public AnaplanImportOperation runImportTask(String importId) throws AnaplanOperationException {
 
         Task task;
         TaskStatus status;
         try {
-            task = imp.createTask();
+            task = getImportService().createTask();
             status = AnaplanUtil.runServerTask(task);
         } catch (AnaplanAPIException e) {
             throw new AnaplanOperationException("Error running Import action:", e);
         }
 
-        // 3. Get task status details and fetch the row counts
+        // Get task status details and fetch the row counts
         String taskDetailsMsg = collectTaskLogs(status);
         setRunStatusDetails(taskDetailsMsg);
         logger.info(getRunStatusDetails());
@@ -125,26 +162,27 @@ public class AnaplanImportOperation extends BaseAnaplanOperation{
             logger.warn("NULL task details from API response!");
         }
 
-        // 3. Determine execution status and create response.
-
+        // Determine execution status and create response.
         final TaskResult taskResult = status.getResult();
         if (taskResult.isFailureDumpAvailable()) {
             logger.info(UserMessages.getMessage("failureDump"));
             final ServerFile failDump = taskResult.getFailureDump();
-            return MulesoftAnaplanResponse.importWithFailureDump(
-                    UserMessages.getMessage("importBadData", importId),
-                    failDump);
+            setResponse(MulesoftAnaplanResponse.importWithFailureDump(
+                UserMessages.getMessage("importBadData", importId),
+                failDump));
         } else {
             logger.info(UserMessages.getMessage("noFailureDump"));
 
             if (taskResult.isSuccessful()) {
-                return MulesoftAnaplanResponse.importSuccess(getRunStatusDetails(),
-                        serverFile);
+                setResponse(MulesoftAnaplanResponse.importSuccess(getRunStatusDetails(),
+                    getServerFile()));
             } else {
-                return MulesoftAnaplanResponse.importFailure(getRunStatusDetails(),
-                        null);
+                setResponse(MulesoftAnaplanResponse.importFailure(getRunStatusDetails(),
+                    null));
             }
         }
+
+        return this;
     }
 
     /**
@@ -156,10 +194,11 @@ public class AnaplanImportOperation extends BaseAnaplanOperation{
      * @throws AnaplanOperationException Internal operation exception thrown to
      *     capture any IOException, JsonSyntaxException or AnaplanAPIException.
      */
-    public String runImport(String data,
+    public String runImport(InputStream data,
                             String workspaceId,
                             String modelId,
-                            String importId) throws AnaplanOperationException {
+                            String importId,
+                            Integer bufferSize) throws AnaplanOperationException {
 
         logger.info("<< Starting import >>");
         logger.info("Workspace-ID: {}", workspaceId);
@@ -173,7 +212,9 @@ public class AnaplanImportOperation extends BaseAnaplanOperation{
         String importResponse = "";
         try {
             logger.info("Starting import: {}", importId);
-            anaplanResponse = runImportCsv(data, model, importId);
+            anaplanResponse = upload(data, model, importId, bufferSize)
+                .runImportTask(importId)
+                .getResponse();
             importResponse = createResponse(anaplanResponse);
             logger.info("Import complete: Status: {}, Response message: {}",
                     anaplanResponse.getStatus(), importResponse);

--- a/src/main/java/com/anaplan/connector/utils/AnaplanUtil.java
+++ b/src/main/java/com/anaplan/connector/utils/AnaplanUtil.java
@@ -22,9 +22,6 @@ import com.anaplan.client.TaskStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.Iterator;
-import java.util.NoSuchElementException;
-
 
 /**
  * Utilities here handle communication with the Anaplan API
@@ -66,59 +63,5 @@ public class AnaplanUtil {
         }
 
         return status;
-    }
-
-    /**
-     * Overloading for stringChunkReader(String, Integer).
-     *
-     * @param data
-     *            String data.
-     * @return
-     */
-    public static Iterator<String> stringChunkReader(final String data) {
-        return stringChunkReader(data, CHUNKSIZE);
-    }
-
-    /**
-     * Data splitter to be used in association with arrayToBase64(). Splits up
-     * the data by provided chunkSize value and returns an iterator to iterate
-     * over each chunk.
-     *
-     * @param data
-     *            Data string, base64 friendly.
-     * @param chunkSize
-     *            Chunk size limit, defaults to 2048 characters.
-     * @return Iterator to iterate over each data-chunk.
-     */
-    public static Iterator<String> stringChunkReader(final String data,
-                                                    final int chunkSize) {
-
-        return new Iterator<String>() {
-
-            int index = 0;
-
-            @Override
-            public boolean hasNext() {
-                return index < data.length();
-            }
-
-            @Override
-            public String next() {
-                String dataChunk;
-                if (hasNext()) {
-                    dataChunk = data.substring(index, Math.min(index + chunkSize,
-                            data.length()));
-                    index += chunkSize;
-                    return dataChunk;
-                }
-                throw new NoSuchElementException("No more chunks to fetch!");
-            }
-
-            @Override
-            public void remove() {
-                throw new UnsupportedOperationException(
-                        "Iterator not fail-safe!");
-            }
-        };
     }
 }

--- a/src/main/java/com/anaplan/connector/utils/BaseAnaplanOperation.java
+++ b/src/main/java/com/anaplan/connector/utils/BaseAnaplanOperation.java
@@ -167,7 +167,7 @@ public class BaseAnaplanOperation {
 	 * @param status TaskStatus object containing task details
 	 * @return Log string delimited by new-line, fetched from TaskStatus object.
 	 */
-	public static String collectTaskLogs(TaskStatus status) {
+	public String collectTaskLogs(TaskStatus status) {
 		final TaskResult taskResult = status.getResult();
 		final StringBuilder taskDetails = new StringBuilder();
 		if (taskResult.getDetails() != null) {

--- a/src/test/java/com/anaplan/connector/unit/BaseUnitTestDriver.java
+++ b/src/test/java/com/anaplan/connector/unit/BaseUnitTestDriver.java
@@ -19,6 +19,7 @@ import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -57,7 +58,7 @@ public abstract class BaseUnitTestDriver {
     protected static final String workspacesResponseFile = "workspaces_response.json";
     protected static final String modelsResponseFile = "models_response.json";
     protected static final String sampleDataFilePath = "sample_data.csv";
-    protected String sampleDataFile;
+    protected InputStream sampleDataStream;
     protected byte[] workspacesResponse;
     protected String apiUrl;
     protected static final String contentType = "application/json";
@@ -96,7 +97,7 @@ public abstract class BaseUnitTestDriver {
     @Before
     public void setUpBase() {
         try {
-            sampleDataFile = new String(getFixture(sampleDataFilePath));
+            sampleDataStream = new ByteArrayInputStream(getFixture(sampleDataFilePath));
             mockAnaplanConnection = Mockito.mock(AnaplanConnection.class);
             apiUrl = properties.getString("anaplan.apiUrl");
             serviceUri = new URI(apiUrl);

--- a/src/test/java/com/anaplan/connector/unit/ExportOperationUnitTestCases.java
+++ b/src/test/java/com/anaplan/connector/unit/ExportOperationUnitTestCases.java
@@ -3,6 +3,7 @@ package com.anaplan.connector.unit;
 import com.anaplan.client.Export;
 import com.anaplan.connector.exceptions.AnaplanOperationException;
 import com.anaplan.connector.utils.AnaplanExportOperation;
+import org.apache.commons.compress.utils.IOUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -49,7 +50,8 @@ public class ExportOperationUnitTestCases extends BaseUnitTestDriver {
         PowerMockito.doReturn(getFixture(exportFileChunksResponseFile))
                     .when(mockTransportProvider)
                     .get(filesPathToken + "/chunks", contentType);
-        PowerMockito.doReturn(sampleDataFile.getBytes())
+	    sampleDataStream.reset();
+        PowerMockito.doReturn(IOUtils.toByteArray(sampleDataStream))
                     .when(mockTransportProvider)
                     .get(filesPathToken + "/chunks/0", null);
     }
@@ -67,7 +69,9 @@ public class ExportOperationUnitTestCases extends BaseUnitTestDriver {
 
         String result = anaplanExportOperation.runExport(workspaceId, modelId,
 				exportId);
-        assertEquals(sampleDataFile, result);
+	    sampleDataStream.reset();
+        assertEquals(new String(IOUtils.toByteArray(sampleDataStream), "UTF-8"),
+	        result);
     }
 
     @Test

--- a/src/test/java/com/anaplan/connector/unit/ImportOperationUnitTestCases.java
+++ b/src/test/java/com/anaplan/connector/unit/ImportOperationUnitTestCases.java
@@ -3,7 +3,6 @@ package com.anaplan.connector.unit;
 import com.anaplan.client.ServerFile;
 import com.anaplan.connector.exceptions.AnaplanOperationException;
 import com.anaplan.connector.utils.AnaplanImportOperation;
-import com.anaplan.connector.utils.AnaplanUtil;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -13,7 +12,10 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.FilterOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 import static org.junit.Assert.assertEquals;
 
@@ -62,13 +64,6 @@ public class ImportOperationUnitTestCases extends BaseUnitTestDriver {
         PowerMockito.doReturn(true).when(mockTaskResult).isSuccessful();
     }
 
-	private void recordActionsStrinkChunkReader() {
-		PowerMockito.when(AnaplanUtil.stringChunkReader(Mockito.anyString()))
-				.thenCallRealMethod();
-		PowerMockito.when(AnaplanUtil.stringChunkReader(Mockito.anyString(),
-				Mockito.anyInt())).thenCallRealMethod();
-	}
-
     @Test
     public void testGoodImportCsv() throws Exception {
         // mock out API calls
@@ -77,10 +72,9 @@ public class ImportOperationUnitTestCases extends BaseUnitTestDriver {
         recordActionsFetchMockItems("files", filesResponseFile);
         recordActionsRunServerTask(importUrlPathToken);
         recordActionsImportTaskResultSuccess();
-		recordActionsStrinkChunkReader();
 
-        anaplanImportOperation.runImport(sampleDataFile, workspaceId, modelId,
-                importId);
+        anaplanImportOperation.runImport(sampleDataStream, workspaceId, modelId,
+                importId, null);
     }
 
 	private void recordActionsImportTaskResultFailureDump() throws Exception {
@@ -103,11 +97,10 @@ public class ImportOperationUnitTestCases extends BaseUnitTestDriver {
 		recordActionsFetchMockImports();
 		recordActionsFetchMockItems("files", filesResponseFile);
 		recordActionsRunServerTask(importUrlPathToken);
-		recordActionsStrinkChunkReader();
 		recordActionsImportTaskResultFailureDump();
 
-		String response = anaplanImportOperation.runImport(sampleDataFile,
-				workspaceId, modelId, importId);
+		String response = anaplanImportOperation.runImport(sampleDataStream,
+				workspaceId, modelId, importId, null);
 		String expectedResponseMsg = "Operation ran successfully but with warnings!\n" +
 				"Response Message:\nSome records were not imported: check " +
 				"connector output data for details: importId\nDump File " +
@@ -124,8 +117,8 @@ public class ImportOperationUnitTestCases extends BaseUnitTestDriver {
         expectedEx.expect(AnaplanOperationException.class);
         expectedEx.expectMessage("Error fetching Import action:");
 
-        anaplanImportOperation.runImport(sampleDataFile, workspaceId, modelId,
-                importId);
+        anaplanImportOperation.runImport(sampleDataStream, workspaceId, modelId,
+                importId, null);
     }
 
     @Test
@@ -138,8 +131,8 @@ public class ImportOperationUnitTestCases extends BaseUnitTestDriver {
         expectedEx.expect(AnaplanOperationException.class);
         expectedEx.expectMessage("Invalid import ID provided: badImportId");
 
-        anaplanImportOperation.runImport(sampleDataFile,
-                workspaceId, modelId, "badImportId");
+        anaplanImportOperation.runImport(sampleDataStream,
+                workspaceId, modelId, "badImportId", null);
     }
 
     @Test
@@ -153,8 +146,8 @@ public class ImportOperationUnitTestCases extends BaseUnitTestDriver {
         expectedEx.expect(AnaplanOperationException.class);
         expectedEx.expectMessage("Error running Import action:");
 
-        anaplanImportOperation.runImport(sampleDataFile, workspaceId, modelId,
-                importId);
+        anaplanImportOperation.runImport(sampleDataStream, workspaceId, modelId,
+                importId, null);
     }
 
 }


### PR DESCRIPTION
- Updated version from 1.1.4 - 1.1.5.
- Updated AnaplanImportOperation to split up the work of uploading the file and running the Import action, as two steps, hence 2 different methods. This will
  be useful for INTEGRA-949.
- Updated to have the @Payload parameter be a InputStream, rather than a String, for good reasons. So now its feeding the contents from the Mulesoft provided InputStream, to the Anaplan provided OutputStream (serverFile.getUploadStream()), in chunks of 1MB.
- Updated unit-tests, tested with small input-files.
- Also tested with large files for Imports, like 111MB - 445MB. 200MB+, the connection drops, but instantly restarts, and keeps doing that until the Import succeeds. Have reported Mulesoft about this, so waiting on a response....
- Updated Import to have a bufferSize argument, mostly for debugging purposes, can be flagged off later.
- Performance updates is also tackling this issue: https://github.com/anaplaninc/anaplan-mulesoft/issues/22
- Updated POM maven-enforcer-plugin version to [1.7,) --> JDK 1.7+
