### PR TITLE
This updates Anaplan to use the latest Devkit version and allows compiling in Java 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <github.global.server>github</github.global.server>
         <mule.modules.list.version>1.1</mule.modules.list.version>
         <anaplan.connect.version>1.3.6</anaplan.connect.version>
-        <org.apache.logging.log4j.version>2.5</org.apache.logging.log4j.version>
+        <org.apache.logging.log4j.version>2.11</org.apache.logging.log4j.version>
         <org.apache.commons.commons-lang3.version>3.4</org.apache.commons.commons-lang3.version>
         <org.apache.commons.commons-csv.version>1.2</org.apache.commons.commons-csv.version>
         <org.apache.commons.io.version>1.3.2</org.apache.commons.io.version>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.mule.tools.devkit</groupId>
         <artifactId>mule-devkit-parent</artifactId>
-        <version>3.9.1</version>
+        <version>3.9.4</version>
     </parent>
 
     <url>http://anaplaninc.github.io/mvn-repos</url>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <github.global.server>github</github.global.server>
         <mule.modules.list.version>1.1</mule.modules.list.version>
         <anaplan.connect.version>1.3.6</anaplan.connect.version>
-        <org.apache.logging.log4j.version>2.11</org.apache.logging.log4j.version>
+        <org.apache.logging.log4j.version>2.11.0</org.apache.logging.log4j.version>
         <org.apache.commons.commons-lang3.version>3.4</org.apache.commons.commons-lang3.version>
         <org.apache.commons.commons-csv.version>1.2</org.apache.commons.commons-csv.version>
         <org.apache.commons.io.version>1.3.2</org.apache.commons.io.version>
@@ -35,6 +35,7 @@
         <coveralls.io.version>4.1.0</coveralls.io.version>
         <cobertura.maven.plugin.version>2.7</cobertura.maven.plugin.version>
         <jdk.version>1.8</jdk.version>
+        <log4j.version>2.11.0</log4j.version>
     </properties>
 
     <dependencies>
@@ -49,6 +50,16 @@
             <groupId>com.anaplan.client</groupId>
             <artifactId>anaplan-connect</artifactId>
             <version>${anaplan.connect.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${log4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,14 +4,14 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.mule.modules</groupId>
     <artifactId>anaplan-connector</artifactId>
-    <version>1.1.4</version>
+    <version>1.1.5</version>
     <packaging>mule-module</packaging>
-    <name>Mulesoft Anaplan Connector</name>
+    <name>Mulesoft Anaplan Connector - JT Updates</name>
 
     <parent>
         <groupId>org.mule.tools.devkit</groupId>
         <artifactId>mule-devkit-parent</artifactId>
-        <version>3.7.1</version>
+        <version>3.9.1</version>
     </parent>
 
     <url>http://anaplaninc.github.io/mvn-repos</url>
@@ -34,6 +34,7 @@
         <maven.compiler.plugin.version>3.5</maven.compiler.plugin.version>
         <coveralls.io.version>4.1.0</coveralls.io.version>
         <cobertura.maven.plugin.version>2.7</cobertura.maven.plugin.version>
+        <jdk.version>1.8</jdk.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
The previous devkit required compiling in Java 1.7 which is EOL.  This version updates the devkit version and other dependencies to allow compiling in Java 1.8